### PR TITLE
Add support for assuming the role specified in AWS_ROLE_ARN when not using WebIdentity

### DIFF
--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -41,7 +41,7 @@ function sessionToken(r) {
  */
 function readCredentials(r) {
     // TODO: Change the generic constants naming for multiple AWS services.
-    if ('S3_ACCESS_KEY_ID' in process.env && 'S3_SECRET_KEY' in process.env) {
+    if ('S3_ACCESS_KEY_ID' in process.env && 'S3_SECRET_KEY' in process.env && !('AWS_ROLE_ARN' in process.env)) {
         const sessionToken = 'S3_SESSION_TOKEN' in process.env ?
                               process.env['S3_SESSION_TOKEN'] : null;
         return {
@@ -132,7 +132,7 @@ function _credentialsTempFile() {
 function writeCredentials(r, credentials) {
     /* Do not bother writing credentials if we are running in a mode where we
        do not need instance credentials. */
-    if (process.env['S3_ACCESS_KEY_ID'] && process.env['S3_SECRET_KEY']) {
+    if (process.env['S3_ACCESS_KEY_ID'] && process.env['S3_SECRET_KEY'] && !('AWS_ROLE_ARN' in process.env)) {
         return;
     }
 

--- a/common/etc/nginx/include/awssig2.js
+++ b/common/etc/nginx/include/awssig2.js
@@ -22,14 +22,14 @@ const mod_hmac = require('crypto');
  * Create HTTP Authorization header for authenticating with an AWS compatible
  * v2 API.
  *
- * @param r {Request} HTTP request object
+ * @param r {Request} HTTP request object (for logging only)
+ * @param method {string} The http method
  * @param uri {string} The URI-encoded version of the absolute path component URL to create a request
  * @param httpDate {string} RFC2616 timestamp used to sign the request
  * @param credentials {object} Credential object with AWS credentials in it (AccessKeyId, SecretAccessKey, SessionToken)
  * @returns {string} HTTP Authorization header value
  */
-function signatureV2(r, uri, httpDate, credentials) {
-    const method = r.method;
+function signatureV2(r, method, uri, httpDate, credentials) {
     const hmac = mod_hmac.createHmac('sha1', credentials.secretAccessKey);
     const stringToSign = method + '\n\n\n' + httpDate + '\n' + uri;
 

--- a/test/unit/awssig2_test.js
+++ b/test/unit/awssig2_test.js
@@ -37,7 +37,7 @@ function _runSignatureV2(r) {
     const httpDate = timestamp.toUTCString();
     const expected = 'AWS test-access-key-1:VviSS4cFhUC6eoB4CYqtRawzDrc=';
     let req = s3gateway._s3ReqParamsForSigV2(r, bucket);
-    let signature = awssig2.signatureV2(r, req.uri, httpDate, creds);
+    let signature = awssig2.signatureV2(r, 'GET', req.path, httpDate, creds);
 
     if (signature !== expected) {
         throw 'V2 signature hash was not created correctly.\n' +

--- a/test/unit/awssig4_test.js
+++ b/test/unit/awssig4_test.js
@@ -71,7 +71,7 @@ function _runSignatureV4(r) {
     //       awssig4.js for the purpose of common library.
     let req = s3gateway._s3ReqParamsForSigV4(r, bucket, server);
     const canonicalRequest = awssig4._buildCanonicalRequest(
-        r.method, req.uri, req.queryParams, req.host, amzDatetime, creds.sessionToken);
+        r.method, req.path, req.queryParams, req.host, amzDatetime, creds.sessionToken);
 
     var expected = 'cf4dd9e1d28c74e2284f938011efc8230d0c20704f56f67e4a3bfc2212026bec';
     var signature = awssig4._buildSignatureV4(


### PR DESCRIPTION
Assume the role specified in AWS_ROLE_ARN if AWS_WEB_IDENTITY_TOKEN_FILE is missing.

Also update some signature code to explicitly pass through the desired method instead of assuming it matches the request. Finally, make it more obvious in signature code that signed components are path rather than a full uri.