### PR TITLE
feat: use dynamic dns resolution for upstreams in oss like plus

### DIFF
--- a/oss/etc/nginx/templates/upstreams.conf.template
+++ b/oss/etc/nginx/templates/upstreams.conf.template
@@ -1,8 +1,11 @@
+# This configuration should dynamically reload S3 backends
+# as they change in DNS.
+
 # Use NGINX's non-blocking DNS resolution
 resolver ${DNS_RESOLVERS};
 
 upstream storage_urls {
-    # Upstreams are not refreshed until NGINX configuration is reloaded.
-    # NGINX Plus will dynamically reload upstreams when DNS records are changed.
-    server ${S3_UPSTREAM};
+    zone s3_backends 64k;
+
+    server ${S3_UPSTREAM} resolve;
 }

--- a/plus/etc/nginx/templates/upstreams.conf.template
+++ b/plus/etc/nginx/templates/upstreams.conf.template
@@ -1,4 +1,4 @@
-# This configuration with NGINX Plus should dynamically reload S3 backends
+# This configuration should dynamically reload S3 backends
 # as they change in DNS.
 
 # Use NGINX's non-blocking DNS resolution


### PR DESCRIPTION
### Proposed changes

This change unifies the OSS upstream configuration with the Plus upstream configuration, so that both are using dynamic DNS reconfiguration for upstreams.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [X] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
