### PR TITLE
fix: Pass GPG key ids as separate arguments when exporting.

### DIFF
--- a/Dockerfile.buildkit.plus
+++ b/Dockerfile.buildkit.plus
@@ -56,7 +56,7 @@ RUN --mount=type=secret,id=nginx-crt,dst=nginx-repo.crt \
     done; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
     done; \
-    gpg1 --export "$NGINX_GPGKEYS" > "$NGINX_GPGKEY_PATH" ; \
+    gpg1 --export $NGINX_GPGKEYS > "$NGINX_GPGKEY_PATH" ; \
     rm -rf "$GNUPGHOME"; \
     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
 # Install the latest release of NGINX Plus and/or NGINX Plus modules (written and maintained by F5)

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -56,7 +56,7 @@ RUN set -x \
     done; \
     test -z "$found" && echo >&2 "error: failed to fetch GPG key $NGINX_GPGKEY" && exit 1; \
     done; \
-    gpg1 --export "$NGINX_GPGKEYS" > "$NGINX_GPGKEY_PATH" ; \
+    gpg1 --export $NGINX_GPGKEYS > "$NGINX_GPGKEY_PATH" ; \
     rm -rf "$GNUPGHOME"; \
     apt-get remove --purge --auto-remove -y gnupg1 && rm -rf /var/lib/apt/lists/* \
 # Install the latest release of NGINX Plus and/or NGINX Plus modules (written and maintained by F5)


### PR DESCRIPTION
This makes sure all keys are exported to a keyring archive, as opposed to only the first key.