### PR TITLE
build(deps): bump nginx from 1.29.1 to 1.29.4 / r35 to 36

### DIFF
--- a/Dockerfile.oss
+++ b/Dockerfile.oss
@@ -1,4 +1,4 @@
-FROM nginx:1.29.1@sha256:d5f28ef21aabddd098f3dbc21fe5b7a7d7a184720bc07da0b6c9b9820e97f25e
+FROM nginx:1.29.4@sha256:ca871a86d45a3ec6864dc45f014b11fe626145569ef0e74deaffc95a3b15b430
 
 # Proxy cache env vars
 ENV PROXY_CACHE_MAX_SIZE=10g

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -1,7 +1,7 @@
 # Pull from NGINX image that provides the XSLT module and supporting libraries
-FROM private-registry.nginx.com/nginx-plus/modules:r35-xslt-debian@sha256:3eaa85dca47e31b9a6648bcaf6034f076cd59be9b1510b25fd1bbe1144f0bb48 AS xslt
+FROM private-registry.nginx.com/nginx-plus/modules:r36-xslt-debian@sha256:54b3e6d9d25f3fb7ad2b93fc7d66ccae1dbc3186b3ce417eda4194a45ee398c3 AS xslt
 
-FROM private-registry.nginx.com/nginx-plus/base:r35-debian-bookworm@sha256:9a82ad3f96d58be861257efd621f215d599e226ebedd24d9f3211bdd743c3c27
+FROM private-registry.nginx.com/nginx-plus/base:r36-debian-trixie@sha256:7dd5de94b8c5d6e726918eb36ea78435efad4f9f63be4325c96919c48603a102
 
 # Proxy cache env vars
 ENV PROXY_CACHE_MAX_SIZE=10g


### PR DESCRIPTION
### Proposed changes
Bumps nginx from 1.29.1 to 1.29.4 and nginx-plus from r35 to r36.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [X] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
