### PR TITLE
fix: prevent hasExtension matching non terminal sub-paths

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -398,7 +398,7 @@ function trailslashControl(r) {
         // consider the uri without query params or anchors
         const path = r.variables.uri_path.split(/[?#]/)[0];
 
-        const hasExtension = /\/[^.\/]+\.[^.]+$/;
+        const hasExtension = /(\/[^\/]*)*(\/[^\/]*\.[^.\/]*)$/;
         if (!hasExtension.test(path)  && !_isDirectory(path)){
             return r.internalRedirect("@trailslash");
         }


### PR DESCRIPTION
### Proposed changes

Update the `s3gateway.js` regular expression for the `hasExtension` check to prevent it from detecting non terminal sub-path as potential part of an extension. This translates in the `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` config enabled behaviour to trigger for paths like `/foo.foo/bar`.

Fixes #522.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
