### PR TITLE
fix: replace deprecated Mercurial njs repository with GitHub mirror

### DIFF
--- a/Dockerfile.latest-njs
+++ b/Dockerfile.latest-njs
@@ -18,7 +18,7 @@ RUN set -eux \
     mkdir -p /tmp/nginx /tmp/njs-latest; \
     curl --retry 6 --location "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
         | gunzip | tar --extract --strip-components=1 --directory /tmp/nginx; \
-    curl --retry 6 --location 'https://hg.nginx.org/njs/archive/tip.tar.gz' \
+    curl --retry 6 --location 'https://github.com/nginx/njs/archive/refs/heads/master.tar.gz' \
         | gunzip | tar --extract --strip-components=1 --directory /tmp/njs-latest; \
     cd /tmp/njs-latest; \
     ./configure; \


### PR DESCRIPTION
### Proposed changes

Fix the broken njs build by replacing the deprecated Mercurial repository URL (`https://hg.nginx.org/njs/archive/tip.tar.gz`) with the official GitHub mirror (`https://github.com/nginx/njs/archive/refs/heads/master.tar.gz`).

The Mercurial service is no longer operational, causing the build to fail.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
