### PR TITLE
fix: rebase images to nginx 1.31.3 / NGINX Plus R37.0 to patch gnutls28 CVEs

### DIFF
--- a/Dockerfile.latest-njs
+++ b/Dockerfile.latest-njs
@@ -11,7 +11,9 @@
 FROM nginx-s3-gateway AS njs-builder
 
 # Build-only dependencies. These stay confined to this stage and are discarded
-# when the final image is assembled, so they do not need to be purged.
+# when the final image is assembled, so they do not need to be purged. The apt
+# package indexes and the unpacked source trees are still removed at the end of
+# the RUN, since this stage's layer is retained in the build cache.
 #
 # Note: libpcre3-dev is deliberately absent. Debian trixie dropped the legacy
 # PCRE1 (pcre3) source package; NGINX and njs build against PCRE2 by way of
@@ -59,7 +61,8 @@ RUN set -eux; \
         --with-cc-opt="-g -O2 -fdebug-prefix-map=/data/builder/debuild/nginx-${NGINX_VERSION}/debian/debuild-base/nginx-${NGINX_VERSION}=. -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC"; \
     make -j "$(nproc)"; \
     cp objs/ngx_stream_js_module.so /usr/lib/nginx/modules; \
-    cp objs/ngx_http_js_module.so /usr/lib/nginx/modules
+    cp objs/ngx_http_js_module.so /usr/lib/nginx/modules; \
+    rm -rf /var/lib/apt/lists/* /tmp/nginx /tmp/njs-latest
 
 # Final runtime image: inherits the clean gateway image and receives only the
 # freshly built njs artifacts. No build toolchain is present here.

--- a/Dockerfile.latest-njs
+++ b/Dockerfile.latest-njs
@@ -1,20 +1,29 @@
-# This container image removes the existing njs package from the inherited image
-# (which could be OSS NGINX or NGINX Plus), builds njs from the latest
-# source, and installs it.
-FROM nginx-s3-gateway
+# This container image builds njs from the latest source and installs it over
+# the njs provided by the inherited image (which could be OSS NGINX or NGINX
+# Plus). Note that the nginx-module-njs package itself is not uninstalled --
+# its files are overwritten in place.
+#
+# The build is split into two stages so that the compiler toolchain and the
+# build-only dependencies (gcc, make, the -dev packages, ...) never reach the
+# shipped runtime image. Only the compiled njs CLI and the two dynamic NGINX
+# modules are copied into the final stage, which keeps the runtime image's
+# package footprint identical to that of the inherited image.
+FROM nginx-s3-gateway AS njs-builder
 
-# Package names with trailing dashes are intentionally specified in order to
-# suppress their install as build dependencies. Those libraries are being
-# provided by the inherited container images and we do not want to mess with
-# them.
-RUN set -eux \
+# Build-only dependencies. These stay confined to this stage and are discarded
+# when the final image is assembled, so they do not need to be purged.
+#
+# Note: libpcre3-dev is deliberately absent. Debian trixie dropped the legacy
+# PCRE1 (pcre3) source package; NGINX and njs build against PCRE2 by way of
+# libpcre2-dev instead.
+RUN set -eux; \
     export DEBIAN_FRONTEND=noninteractive; \
     export NGINX_VERSION="$(nginx -V 2>&1 | grep 'nginx version' | awk -F'[/ ]' '{print $4}')"; \
     apt-get update -qq; \
     apt-get install --no-install-recommends --no-install-suggests --yes --allow-change-held-packages \
         make gcc libc6-dev curl expect libpcre2-dev \
-        libpcre3-dev libedit-dev libreadline-dev libssl-dev libpcre2-posix3 libxml2-dev libxslt1-dev zlib1g-dev \
-        libgcrypt20 libicu-dev libssl-dev libxslt1-dev- libxml2-dev-; \
+        libedit-dev libreadline-dev libssl-dev libpcre2-posix3 libxml2-dev libxslt1-dev zlib1g-dev \
+        libgcrypt20 libicu-dev; \
     mkdir -p /tmp/nginx /tmp/njs-latest; \
     curl --retry 6 --location "https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz" \
         | gunzip | tar --extract --strip-components=1 --directory /tmp/nginx; \
@@ -50,8 +59,12 @@ RUN set -eux \
         --with-cc-opt="-g -O2 -fdebug-prefix-map=/data/builder/debuild/nginx-${NGINX_VERSION}/debian/debuild-base/nginx-${NGINX_VERSION}=. -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC"; \
     make -j "$(nproc)"; \
     cp objs/ngx_stream_js_module.so /usr/lib/nginx/modules; \
-    cp objs/ngx_http_js_module.so /usr/lib/nginx/modules; \
-    apt-get purge --yes --auto-remove make gcc libc6-dev expect libpcre2-dev libpcre3-dev libedit-dev libreadline-dev libssl-dev zlib1g-dev; \
-    rm -rf \
-      /var/lib/apt/lists/* \
-      /tmp/*
+    cp objs/ngx_http_js_module.so /usr/lib/nginx/modules
+
+# Final runtime image: inherits the clean gateway image and receives only the
+# freshly built njs artifacts. No build toolchain is present here.
+FROM nginx-s3-gateway
+
+COPY --from=njs-builder /usr/lib/nginx/modules/ngx_http_js_module.so /usr/lib/nginx/modules/ngx_http_js_module.so
+COPY --from=njs-builder /usr/lib/nginx/modules/ngx_stream_js_module.so /usr/lib/nginx/modules/ngx_stream_js_module.so
+COPY --from=njs-builder /usr/bin/njs /usr/bin/njs

--- a/Dockerfile.oss
+++ b/Dockerfile.oss
@@ -1,4 +1,4 @@
-FROM nginx:1.29.1@sha256:d5f28ef21aabddd098f3dbc21fe5b7a7d7a184720bc07da0b6c9b9820e97f25e
+FROM nginx:1.31.3@sha256:8541484afbc9c8a5a8a99b379568ebbc957f658583ec9448fc43104229c03cf8
 
 # Proxy cache env vars
 ENV PROXY_CACHE_MAX_SIZE=10g

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -1,7 +1,7 @@
 # Pull from NGINX image that provides the XSLT module and supporting libraries
-FROM private-registry.nginx.com/nginx-plus/modules:r35-xslt-debian@sha256:3eaa85dca47e31b9a6648bcaf6034f076cd59be9b1510b25fd1bbe1144f0bb48 AS xslt
+FROM private-registry.nginx.com/nginx-plus/modules:r37.0-xslt-debian@sha256:0b4c950977bb5670f450c4c5428e9d4e931e12919dd97e72517c6ab8d5d52501 AS xslt
 
-FROM private-registry.nginx.com/nginx-plus/base:r35-debian-bookworm@sha256:9a82ad3f96d58be861257efd621f215d599e226ebedd24d9f3211bdd743c3c27
+FROM private-registry.nginx.com/nginx-plus/base:r37.0-debian-trixie@sha256:00bdd05087c951211a1bec52c90bd76ddbe82b4b6be7405beaaa605e5b950a3e
 
 # Proxy cache env vars
 ENV PROXY_CACHE_MAX_SIZE=10g


### PR DESCRIPTION
## What

Rebases both gateway container images onto newer base images to pick up patched `gnutls28` packages:

- **OSS image** (`Dockerfile.oss`): `nginx:1.29.1` → `nginx:1.31.3` (pinned by digest)
- **Plus image** (`Dockerfile.plus`): NGINX Plus R35 on Debian bookworm → R37.0 on Debian trixie (both the base and XSLT-module stages, pinned by digest)

## Why

The previous base images ship `gnutls28` builds with known CVEs. Rebasing onto the current upstream images pulls in the patched packages.

## Related changes

`Dockerfile.latest-njs` needed rework to build on trixie and was converted to a proper multi-stage build:

- Debian trixie dropped the legacy PCRE1 (`pcre3`) source package, so `libpcre3-dev` is removed from the build dependencies; njs and NGINX build against PCRE2 via `libpcre2-dev`.
- The njs compile now happens in a dedicated `njs-builder` stage. Only the compiled njs CLI and the two dynamic NGINX modules are copied into the final image, so the compiler toolchain and `-dev` packages never reach the shipped runtime image (previously they were installed and then purged in the same layer).