### PR TITLE
fix: do not cache a non-200 EKS Pod Identity agent response as credentials

### DIFF
--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -407,9 +407,9 @@ async function _fetchEKSPodIdentityCredentials() {
             'Authorization': token,
         },
     });
-    if (!resp.ok) {
-        throw 'Credentials endpoint response was not ok.';
-    }
+if (!resp.ok) {
+    throw `Credentials endpoint response was not ok (status: ${resp.status}).`;
+}
     const creds = await resp.json();
 
     return {

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -407,6 +407,9 @@ async function _fetchEKSPodIdentityCredentials() {
             'Authorization': token,
         },
     });
+    if (!resp.ok) {
+        throw 'Credentials endpoint response was not ok.';
+    }
     const creds = await resp.json();
 
     return {

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -372,10 +372,63 @@ async function testEKSPodIdentityCredentialRetrieval() {
     }
 }
 
+async function testEKSPodIdentityCredentialRetrievalNon200Response() {
+    printHeader('testEKSPodIdentityCredentialRetrievalNon200Response');
+    if ('AWS_ACCESS_KEY_ID' in process.env) {
+        delete process.env['AWS_ACCESS_KEY_ID'];
+    }
+    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+    }
+    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
+    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
+    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var testToken = 'A_TOKEN';
+    fs.writeFileSync(tempFile, testToken);
+    process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] = tempFile;
+    globalThis.errorBodyParsedAsCredentials = false;
+    globalThis.ngx.fetch = function(url, options) {
+        console.log(' fetching eks pod identity mock error response');
+        return Promise.resolve({
+            ok: false,
+            status: 503,
+            json: function() {
+                // A non-200 body must never be parsed as credentials.
+                globalThis.errorBodyParsedAsCredentials = true;
+                return Promise.resolve({
+                    message: 'Service Unavailable',
+                });
+            },
+        });
+    };
+    var returnedCode = null;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            returnedCode = code;
+        },
+    };
+
+    await awscred.fetchCredentials(r);
+
+    if (globalThis.errorBodyParsedAsCredentials) {
+        throw 'A non-200 EKS Pod Identity agent response was parsed as credentials.';
+    }
+    if (returnedCode !== 500) {
+        throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+    }
+}
+
 async function test() {
     await testEc2CredentialRetrieval();
     await testEcsCredentialRetrieval();
     await testEKSPodIdentityCredentialRetrieval();
+    await testEKSPodIdentityCredentialRetrievalNon200Response();
     testReadCredentialsWithAccessSecretKeyAndSessionTokenSet();
     testReadCredentialsFromFilePath();
     testReadCredentialsFromNonexistentPath();


### PR DESCRIPTION
### Proposed changes

Fixes #537.

`_fetchEKSPodIdentityCredentials` calls `resp.json()` without checking `resp.ok`. When the EKS Pod Identity agent answers non-200 (token rotation blip, agent restart, throttling), the error body is parsed as if it were credentials, `writeCredentials` caches `{accessKeyId: undefined, ...}`, and every S3 request is then signed with those values. S3 rejects them with 400, which the gateway sanitizes to 404, so the whole site serves 404 for existing objects until a later refresh succeeds. Details and production evidence in the linked issue.

This adds the same `resp.ok` guard `_fetchEcsRoleCredentials` already has, so a failed refresh throws (surfacing as the existing 500 path in `fetchCredentials`) and the previously cached credentials, normally still valid through an agent blip, are kept instead of being overwritten.

Also adds an error-path unit test: a mocked non-200 agent response must produce a 500 from `fetchCredentials` and must never have its body parsed as credentials. Verified with the repo's unit harness against the published image (`njs -m -p /etc/nginx /var/tmp/awscredentials_test.js` in `unprivileged-oss-20260810`): all existing tests still pass and the new test passes with the guard, failing without it.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)