### PR TITLE
ci: run required checks on merge_group so the merge queue can pass

### DIFF
--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Required status checks must also run on the merge queue's temporary
+  # branches or queued PRs time out waiting for them and are ejected.
+  merge_group:
   schedule:
     - cron: "0 0 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
The `main` ruleset routes all merges through a merge queue that requires the seven build/test checks from `s3-gateway.yml`, but that workflow has no `merge_group` trigger. The required checks therefore never start on the queue's temporary branch, and every queued PR is ejected after the 60-minute `check_response_timeout` (e.g. #493 was removed with reason `checks_timed_out`).

This adds the `merge_group` trigger so the required checks run in queue merges. The `tag-and-push` publish job is unaffected: it is gated on `github.ref == 'refs/heads/main'`, and merge-queue runs execute on `gh-readonly-queue/...` refs, so images are still only pushed on the final push to `main`.

Note: this PR itself cannot pass through the broken queue and needs one administrative bypass merge; after that the queue works normally.