### PR TITLE
ci: add network timeouts and retries to apt-get steps

### DIFF
--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -69,7 +69,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
+        # step until the job timeout and knocks PRs out of the merge queue.
+        timeout-minutes: 5
+        run: |
+          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
+          sudo apt-get $APT_OPTS update -qq
+          sudo apt-get $APT_OPTS install -y curl wait-for-it
 
       - name: Restore cached binaries
         id: cache-binaries-restore
@@ -155,7 +161,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
+        # step until the job timeout and knocks PRs out of the merge queue.
+        timeout-minutes: 5
+        run: |
+          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
+          sudo apt-get $APT_OPTS update -qq
+          sudo apt-get $APT_OPTS install -y curl wait-for-it
 
       - name: Restore cached binaries
         id: cache-binaries-restore
@@ -242,7 +254,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
+        # step until the job timeout and knocks PRs out of the merge queue.
+        timeout-minutes: 5
+        run: |
+          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
+          sudo apt-get $APT_OPTS update -qq
+          sudo apt-get $APT_OPTS install -y curl wait-for-it
 
       - name: Restore cached binaries
         id: cache-binaries-restore


### PR DESCRIPTION
The `Install dependencies` step (`apt-get update && apt-get install curl wait-for-it`) has hung indefinitely on a wedged mirror at least 8 times in the last 24 hours, each time either stalling CI for an hour+ (before #541) or burning the full 30-minute job timeout and ejecting PRs from the merge queue with `failed_checks` (after #541 — GitHub reports timed-out jobs as cancelled). PR #471 has been knocked out of the queue twice by exactly this.

Adds `Acquire::http(s)::Timeout=30` and `Acquire::Retries=3` so a stalled connection fails fast and retries, plus a step-level `timeout-minutes: 5` backstop so a residual hang costs 5 minutes instead of 30.