### PR TITLE
fix: guard all credential fetch paths against non-200 responses

### DIFF
--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -289,7 +289,7 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchEcsRoleCredentials(uri);
         } catch (e) {
-            utils.debug_log(r, 'Could not load ECS task role credentials: ' + JSON.stringify(e));
+            utils.debug_log(r, `Could not load ECS task role credentials: ${e}`);
             r.return(500);
             return;
         }
@@ -298,7 +298,7 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchWebIdentityCredentials(r)
         } catch (e) {
-            utils.debug_log(r, 'Could not assume role using web identity: ' + JSON.stringify(e));
+            utils.debug_log(r, `Could not assume role using web identity: ${e}`);
             r.return(500);
             return;
         }
@@ -307,7 +307,7 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchEKSPodIdentityCredentials(r)
         } catch (e) {
-            utils.debug_log(r, 'Could not assume role using EKS pod identity: ' + JSON.stringify(e));
+            utils.debug_log(r, `Could not assume role using EKS pod identity: ${e}`);
             r.return(500);
             return;
         }
@@ -315,7 +315,7 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchEC2RoleCredentials(r);
         } catch (e) {
-            utils.debug_log(r, 'Could not load EC2 task role credentials: ' + JSON.stringify(e));
+            utils.debug_log(r, `Could not load EC2 task role credentials: ${e}`);
             r.return(500);
             return;
         }
@@ -331,6 +331,20 @@ async function fetchCredentials(r) {
 }
 
 /**
+ * Throws when a credentials-endpoint response has a non-2xx status so that
+ * error response bodies are never parsed as credentials.
+ *
+ * @param resp {Response} response object returned by ngx.fetch
+ * @param endpointName {string} human-readable endpoint name for the error
+ * @private
+ */
+function _checkResponseOk(resp, endpointName) {
+    if (!resp.ok) {
+        throw `${endpointName} response was not ok (status: ${resp.status}).`;
+    }
+}
+
+/**
  * Get the credentials needed to generate AWS signatures from the ECS
  * (Elastic Container Service) metadata endpoint.
  *
@@ -340,9 +354,7 @@ async function fetchCredentials(r) {
  */
 async function _fetchEcsRoleCredentials(credentialsUri) {
     const resp = await ngx.fetch(credentialsUri);
-    if (!resp.ok) {
-        throw `ECS credentials endpoint response was not ok (status: ${resp.status}).`;
-    }
+    _checkResponseOk(resp, 'ECS credentials endpoint');
     const creds = await resp.json();
 
     return {
@@ -362,7 +374,14 @@ async function _fetchEcsRoleCredentials(credentialsUri) {
  * @private
  */
 async function _fetchEC2RoleCredentials(r) {
+    /* Standard AWS SDK setting: when true, never fall back to IMDSv1 -
+       credential retrieval fails closed when an IMDSv2 token cannot be
+       obtained.
+       See: https://docs.aws.amazon.com/sdkref/latest/guide/feature-imds-credentials.html */
+    const imdsV1Disabled = utils.parseBoolean(
+        process.env['AWS_EC2_METADATA_V1_DISABLED'] || 'false');
     let tokenResp = null;
+    let imdsV1FallbackReason = null;
     try {
         tokenResp = await ngx.fetch(EC2_IMDS_TOKEN_ENDPOINT, {
             headers: {
@@ -376,6 +395,11 @@ async function _fetchEC2RoleCredentials(r) {
            whose HttpPutResponseHopLimit is too low for the gateway's network
            position (e.g. running inside a container behind a bridge network),
            where the token response is dropped but IMDSv1 GETs succeed. */
+        if (imdsV1Disabled) {
+            throw `IMDSv2 token request failed (${e}) and IMDSv1 fallback ` +
+                'is disabled by AWS_EC2_METADATA_V1_DISABLED.';
+        }
+        imdsV1FallbackReason = `the IMDSv2 token request failed (${e})`;
         utils.debug_log(r, `EC2 IMDS token request failed (${e}), falling back to IMDSv1`);
     }
     /* Fall back to IMDSv1 (no session token) when the IMDSv2 token request is
@@ -388,19 +412,29 @@ async function _fetchEC2RoleCredentials(r) {
     if (tokenResp) {
         if (tokenResp.ok) {
             headers['x-aws-ec2-metadata-token'] = await tokenResp.text();
+        } else if (imdsV1Disabled) {
+            throw `IMDS token endpoint response was not ok (status: ${tokenResp.status}) ` +
+                'and IMDSv1 fallback is disabled by AWS_EC2_METADATA_V1_DISABLED.';
         } else if (tokenResp.status === 403 || tokenResp.status === 404 ||
                    tokenResp.status === 405) {
+            imdsV1FallbackReason = `the IMDS token endpoint returned status ${tokenResp.status}`;
             utils.debug_log(r, `EC2 IMDS token endpoint returned status ${tokenResp.status}, falling back to IMDSv1`);
         } else {
-            throw `IMDS token endpoint response was not ok (status: ${tokenResp.status}).`;
+            _checkResponseOk(tokenResp, 'IMDS token endpoint');
         }
     }
     let resp = await ngx.fetch(EC2_IMDS_SECURITY_CREDENTIALS_ENDPOINT, {
         headers: headers,
     });
-    if (!resp.ok) {
-        throw `Security credentials endpoint response was not ok (status: ${resp.status}).`;
+    if (!resp.ok && imdsV1FallbackReason) {
+        /* Without this attribution, an IMDSv2-required instance surfaces only
+           the 401 from the token-less GET, hiding the token failure that
+           caused the downgrade. */
+        throw `Security credentials endpoint response was not ok (status: ${resp.status}) ` +
+            `after falling back to IMDSv1 because ${imdsV1FallbackReason}; ` +
+            'the instance may require IMDSv2.';
     }
+    _checkResponseOk(resp, 'Security credentials endpoint');
     /* This _might_ get multiple possible roles in other scenarios, however,
        EC2 supports attaching one role only.It should therefore be safe to take
        the whole output, even given IMDS _might_ (?) be able to return multiple
@@ -412,9 +446,7 @@ async function _fetchEC2RoleCredentials(r) {
     resp = await ngx.fetch(EC2_IMDS_SECURITY_CREDENTIALS_ENDPOINT + credName, {
         headers: headers,
     });
-    if (!resp.ok) {
-        throw `EC2 role credentials endpoint response was not ok (status: ${resp.status}).`;
-    }
+    _checkResponseOk(resp, 'EC2 role credentials endpoint');
     const creds = await resp.json();
 
     return {
@@ -433,15 +465,16 @@ async function _fetchEC2RoleCredentials(r) {
  * @private
  */
 async function _fetchEKSPodIdentityCredentials() {
-    const token = fs.readFileSync(process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE']);
+    /* Trim the token so a trailing newline in a hand-created token file does
+       not produce an invalid Authorization header value; tokens themselves
+       never contain whitespace. */
+    const token = fs.readFileSync(process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE']).toString().trim();
     let resp = await ngx.fetch(EKS_POD_IDENTITY_AGENT_CREDENTIALS_ENDPOINT, {
         headers: {
             'Authorization': token,
         },
     });
-    if (!resp.ok) {
-        throw `EKS Pod Identity credentials endpoint response was not ok (status: ${resp.status}).`;
-    }
+    _checkResponseOk(resp, 'EKS Pod Identity credentials endpoint');
     const creds = await resp.json();
 
     return {
@@ -488,7 +521,10 @@ async function _fetchWebIdentityCredentials(r) {
         }
     }
 
-    const token = fs.readFileSync(process.env['AWS_WEB_IDENTITY_TOKEN_FILE']);
+    /* Trim the token so a trailing newline in a hand-created token file is
+       not percent-encoded into the token value (STS would reject it); JWTs
+       and OAuth tokens never contain leading or trailing whitespace. */
+    const token = fs.readFileSync(process.env['AWS_WEB_IDENTITY_TOKEN_FILE']).toString().trim();
 
     /* Percent-encode the values - IAM role session names may legally contain
        '+' and '=', and web identity tokens that are not base64url-encoded

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -439,6 +439,9 @@ async function _fetchEKSPodIdentityCredentials() {
             'Authorization': token,
         },
     });
+    if (!resp.ok) {
+        throw `EKS Pod Identity credentials endpoint response was not ok (status: ${resp.status}).`;
+    }
     const creds = await resp.json();
 
     return {

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -313,7 +313,7 @@ async function fetchCredentials(r) {
         }
     } else {
         try {
-            credentials = await _fetchEC2RoleCredentials();
+            credentials = await _fetchEC2RoleCredentials(r);
         } catch (e) {
             utils.debug_log(r, 'Could not load EC2 task role credentials: ' + JSON.stringify(e));
             r.return(500);
@@ -341,7 +341,7 @@ async function fetchCredentials(r) {
 async function _fetchEcsRoleCredentials(credentialsUri) {
     const resp = await ngx.fetch(credentialsUri);
     if (!resp.ok) {
-        throw 'Credentials endpoint response was not ok.';
+        throw `ECS credentials endpoint response was not ok (status: ${resp.status}).`;
     }
     const creds = await resp.json();
 
@@ -357,22 +357,43 @@ async function _fetchEcsRoleCredentials(credentialsUri) {
  * Get the credentials needed to generate AWS signatures from the EC2
  * metadata endpoint.
  *
+ * @param r {NginxHTTPRequest} HTTP request object
  * @returns {Promise<Credentials>}
  * @private
  */
-async function _fetchEC2RoleCredentials() {
-    const tokenResp = await ngx.fetch(EC2_IMDS_TOKEN_ENDPOINT, {
-        headers: {
-            'x-aws-ec2-metadata-token-ttl-seconds': '21600',
-        },
-        method: 'PUT',
-    });
+async function _fetchEC2RoleCredentials(r) {
+    let tokenResp = null;
+    try {
+        tokenResp = await ngx.fetch(EC2_IMDS_TOKEN_ENDPOINT, {
+            headers: {
+                'x-aws-ec2-metadata-token-ttl-seconds': '21600',
+            },
+            method: 'PUT',
+        });
+    } catch (e) {
+        /* A network error or timeout on the token request falls back to
+           IMDSv1 below, matching AWS SDK behavior. This covers instances
+           whose HttpPutResponseHopLimit is too low for the gateway's network
+           position (e.g. running inside a container behind a bridge network),
+           where the token response is dropped but IMDSv1 GETs succeed. */
+        utils.debug_log(r, `EC2 IMDS token request failed (${e}), falling back to IMDSv1`);
+    }
     /* Fall back to IMDSv1 (no session token) when the IMDSv2 token request is
-       rejected, matching AWS SDK behavior with IMDSv1-only metadata services
-       such as older metadata emulators. */
+       rejected with 403/404/405, matching AWS SDK behavior with IMDSv1-only
+       metadata services such as older metadata emulators. Other failure
+       statuses (e.g. 429/5xx throttling on an IMDSv2-required instance) are
+       fatal so that the root cause is surfaced instead of the misleading 401
+       a token-less request would produce. */
     const headers = {};
-    if (tokenResp.ok) {
-        headers['x-aws-ec2-metadata-token'] = await tokenResp.text();
+    if (tokenResp) {
+        if (tokenResp.ok) {
+            headers['x-aws-ec2-metadata-token'] = await tokenResp.text();
+        } else if (tokenResp.status === 403 || tokenResp.status === 404 ||
+                   tokenResp.status === 405) {
+            utils.debug_log(r, `EC2 IMDS token endpoint returned status ${tokenResp.status}, falling back to IMDSv1`);
+        } else {
+            throw `IMDS token endpoint response was not ok (status: ${tokenResp.status}).`;
+        }
     }
     let resp = await ngx.fetch(EC2_IMDS_SECURITY_CREDENTIALS_ENDPOINT, {
         headers: headers,
@@ -392,7 +413,7 @@ async function _fetchEC2RoleCredentials() {
         headers: headers,
     });
     if (!resp.ok) {
-        throw `Credentials endpoint response was not ok (status: ${resp.status}).`;
+        throw `EC2 role credentials endpoint response was not ok (status: ${resp.status}).`;
     }
     const creds = await resp.json();
 
@@ -466,7 +487,11 @@ async function _fetchWebIdentityCredentials(r) {
 
     const token = fs.readFileSync(process.env['AWS_WEB_IDENTITY_TOKEN_FILE']);
 
-    const params = `Version=2011-06-15&Action=AssumeRoleWithWebIdentity&RoleArn=${arn}&RoleSessionName=${name}&WebIdentityToken=${token}`;
+    /* Percent-encode the values - IAM role session names may legally contain
+       '+' and '=', and web identity tokens that are not base64url-encoded
+       JWTs (e.g. OAuth access tokens) may contain characters that corrupt
+       query-string parsing when left unencoded. */
+    const params = `Version=2011-06-15&Action=AssumeRoleWithWebIdentity&RoleArn=${encodeURIComponent(arn)}&RoleSessionName=${encodeURIComponent(name)}&WebIdentityToken=${encodeURIComponent(token)}`;
 
     const response = await ngx.fetch(sts_endpoint + "?" + params, {
         headers: {
@@ -475,7 +500,10 @@ async function _fetchWebIdentityCredentials(r) {
         method: 'GET',
     });
     if (!response.ok) {
-        const errorBody = await response.text();
+        /* Cap the amount of the error body kept so that an unexpectedly large
+           error document cannot balloon the thrown message; real STS error
+           bodies are far smaller than this. */
+        const errorBody = (await response.text()).slice(0, 1024);
         throw `STS endpoint response was not ok (status: ${response.status}, body: ${errorBody}).`;
     }
 

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -196,8 +196,11 @@ function writeCredentials(r, credentials) {
         return;
     }
 
-    if (!credentials) {
-        throw `Cannot write invalid credentials: ${JSON.stringify(credentials)}`;
+    /* Guard against caching malformed credentials (such as an error response
+       body that was mistakenly parsed as credentials) - field values are
+       deliberately not logged so that secrets cannot leak into logs. */
+    if (!credentials || !credentials.accessKeyId || !credentials.secretAccessKey) {
+        throw 'Cannot write invalid credentials: missing accessKeyId or secretAccessKey';
     }
 
     if ("variables" in r && r.variables.cache_instance_credentials_enabled == 1) {
@@ -364,12 +367,19 @@ async function _fetchEC2RoleCredentials() {
         },
         method: 'PUT',
     });
-    const token = await tokenResp.text();
+    /* Fall back to IMDSv1 (no session token) when the IMDSv2 token request is
+       rejected, matching AWS SDK behavior with IMDSv1-only metadata services
+       such as older metadata emulators. */
+    const headers = {};
+    if (tokenResp.ok) {
+        headers['x-aws-ec2-metadata-token'] = await tokenResp.text();
+    }
     let resp = await ngx.fetch(EC2_IMDS_SECURITY_CREDENTIALS_ENDPOINT, {
-        headers: {
-            'x-aws-ec2-metadata-token': token,
-        },
+        headers: headers,
     });
+    if (!resp.ok) {
+        throw `Security credentials endpoint response was not ok (status: ${resp.status}).`;
+    }
     /* This _might_ get multiple possible roles in other scenarios, however,
        EC2 supports attaching one role only.It should therefore be safe to take
        the whole output, even given IMDS _might_ (?) be able to return multiple
@@ -379,10 +389,11 @@ async function _fetchEC2RoleCredentials() {
         throw 'No credentials available for EC2 instance';
     }
     resp = await ngx.fetch(EC2_IMDS_SECURITY_CREDENTIALS_ENDPOINT + credName, {
-        headers: {
-            'x-aws-ec2-metadata-token': token,
-        },
+        headers: headers,
     });
+    if (!resp.ok) {
+        throw `Credentials endpoint response was not ok (status: ${resp.status}).`;
+    }
     const creds = await resp.json();
 
     return {
@@ -463,6 +474,10 @@ async function _fetchWebIdentityCredentials(r) {
         },
         method: 'GET',
     });
+    if (!response.ok) {
+        const errorBody = await response.text();
+        throw `STS endpoint response was not ok (status: ${response.status}, body: ${errorBody}).`;
+    }
 
     const resp = await response.json();
     const creds = resp.AssumeRoleWithWebIdentityResponse.AssumeRoleWithWebIdentityResult.Credentials;

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -346,6 +346,18 @@ aws ec2 modify-instance-metadata-options --instance-id <instance id> \
 After that has been run we can start the container normally and omit the
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
 
+Note: when the IMDSv2 token request fails with a network error or is rejected
+with a 403/404/405 status, the gateway automatically retries without a session
+token (IMDSv1), matching AWS SDK behavior. This lets the gateway work on
+instances where the hop limit was not raised, but only when the instance still
+allows IMDSv1 (`HttpTokens=optional`); each credential refresh then waits for
+the token request to time out first. Instances enforcing IMDSv2
+(`HttpTokens=required`) still require the hop limit change above.
+
+To disable the IMDSv1 fallback entirely so that credential retrieval fails
+closed when an IMDSv2 token cannot be obtained, set the standard AWS SDK
+environment variable `AWS_EC2_METADATA_V1_DISABLED=true`.
+
 ### Running in ECS with an IAM Policy
 
 The commands below all reference the [`deployments/ecs/cloudformation/s3gateway.cf`](/deployments/ecs/cloudformation/s3gateway.yaml) file. This file will need to be

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -154,11 +154,10 @@ function testReadAndWriteCredentialsFromKeyValStore() {
             }
         };
         let expectedCredentials = {
-            AccessKeyId: 'AN_ACCESS_KEY_ID',
-            Expiration: '2017-05-17T15:09:54Z',
-            RoleArn: 'TASK_ROLE_ARN',
-            SecretAccessKey: 'A_SECRET_ACCESS_KEY',
-            Token: 'A_SECURITY_TOKEN',
+            accessKeyId: 'AN_ACCESS_KEY_ID',
+            secretAccessKey: 'A_SECRET_ACCESS_KEY',
+            sessionToken: 'A_SECURITY_TOKEN',
+            expiration: '2017-05-17T15:09:54Z',
         };
 
         awscred.writeCredentials(r, expectedCredentials);
@@ -372,14 +371,323 @@ async function testEKSPodIdentityCredentialRetrieval() {
     }
 }
 
+async function testEc2CredentialRetrievalNon200Response() {
+    printHeader('testEc2CredentialRetrievalNon200Response');
+    if ('AWS_ACCESS_KEY_ID' in process.env) {
+        delete process.env['AWS_ACCESS_KEY_ID'];
+    }
+    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+    }
+    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+    }
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
+    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
+    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var non200ResponseServed = false;
+    var errorBodyParsedAsCredentials = false;
+    var returnedCode = null;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            returnedCode = code;
+        },
+    };
+    globalThis.ngx.fetch = function (url, options) {
+        if (url === 'http://169.254.169.254/latest/api/token' && options && options.method === 'PUT') {
+            return Promise.resolve({
+                ok: true,
+                text: function () {
+                    return Promise.resolve('A_TOKEN');
+                },
+            });
+        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/') {
+            return Promise.resolve({
+                ok: true,
+                text: function () {
+                    return Promise.resolve('A_ROLE_NAME');
+                },
+            });
+        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/A_ROLE_NAME') {
+            non200ResponseServed = true;
+            return Promise.resolve({
+                ok: false,
+                status: 503,
+                json: function () {
+                    // A non-200 body must never be parsed as credentials.
+                    errorBodyParsedAsCredentials = true;
+                    return Promise.resolve({
+                        message: 'Service Unavailable',
+                    });
+                },
+            });
+        } else {
+            throw 'Invalid request URL: ' + url;
+        }
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+
+        if (!non200ResponseServed) {
+            throw 'The mocked non-200 EC2 credentials response was never served.';
+        }
+        if (errorBodyParsedAsCredentials) {
+            throw 'A non-200 EC2 metadata response was parsed as credentials.';
+        }
+        if (returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        }
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            throw 'Credentials must not be cached from a non-200 response.';
+        }
+    } finally {
+        if (originalCredentialPath) {
+            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
+        } else {
+            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
+        }
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            fs.unlinkSync(tempFile);
+        }
+    }
+}
+
+async function testEc2CredentialRetrievalIMDSv1Fallback() {
+    printHeader('testEc2CredentialRetrievalIMDSv1Fallback');
+    if ('AWS_ACCESS_KEY_ID' in process.env) {
+        delete process.env['AWS_ACCESS_KEY_ID'];
+    }
+    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+    }
+    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+    }
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
+    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
+    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var credentialsIssued = false;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            if (code !== 200) {
+                throw 'Expected 200 status code, got: ' + code;
+            }
+        },
+    };
+    globalThis.ngx.fetch = function (url, options) {
+        if (url === 'http://169.254.169.254/latest/api/token' && options && options.method === 'PUT') {
+            // Simulate an IMDSv1-only metadata service rejecting the token request.
+            return Promise.resolve({
+                ok: false,
+                status: 405,
+            });
+        }
+        if (options && options.headers && 'x-aws-ec2-metadata-token' in options.headers) {
+            throw 'IMDSv2 token header must not be sent after a rejected token request';
+        }
+        if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/') {
+            return Promise.resolve({
+                ok: true,
+                text: function () {
+                    return Promise.resolve('A_ROLE_NAME');
+                },
+            });
+        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/A_ROLE_NAME') {
+            return Promise.resolve({
+                ok: true,
+                json: function () {
+                    credentialsIssued = true;
+                    return Promise.resolve({
+                        AccessKeyId: 'AN_ACCESS_KEY_ID',
+                        Expiration: '2017-05-17T15:09:54Z',
+                        RoleArn: 'TASK_ROLE_ARN',
+                        SecretAccessKey: 'A_SECRET_ACCESS_KEY',
+                        Token: 'A_SECURITY_TOKEN',
+                    });
+                },
+            });
+        } else {
+            throw 'Invalid request URL: ' + url;
+        }
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+
+        if (!credentialsIssued) {
+            throw 'Did not reach the point where EC2 credentials were issued via IMDSv1.';
+        }
+    } finally {
+        if (originalCredentialPath) {
+            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
+        } else {
+            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
+        }
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            fs.unlinkSync(tempFile);
+        }
+    }
+}
+
+async function testWebIdentityCredentialRetrievalNon200Response() {
+    printHeader('testWebIdentityCredentialRetrievalNon200Response');
+    if ('AWS_ACCESS_KEY_ID' in process.env) {
+        delete process.env['AWS_ACCESS_KEY_ID'];
+    }
+    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
+        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+    }
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
+    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
+    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var tokenFile = `${tempDir}/web-identity-token-unit-test-${uniqId}`;
+    fs.writeFileSync(tokenFile, 'A_WEB_IDENTITY_TOKEN');
+    var non200ResponseServed = false;
+    var errorBodyParsedAsCredentials = false;
+    var returnedCode = null;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            returnedCode = code;
+        },
+    };
+    globalThis.ngx.fetch = function (url) {
+        if (url.startsWith('https://sts.unit-test.example.com?')) {
+            non200ResponseServed = true;
+            return Promise.resolve({
+                ok: false,
+                status: 400,
+                text: function () {
+                    return Promise.resolve('{"Error":{"Code":"ExpiredTokenException"}}');
+                },
+                json: function () {
+                    // A non-200 body must never be parsed as credentials.
+                    errorBodyParsedAsCredentials = true;
+                    return Promise.resolve({});
+                },
+            });
+        } else {
+            throw 'Invalid request URL: ' + url;
+        }
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        process.env['AWS_WEB_IDENTITY_TOKEN_FILE'] = tokenFile;
+        process.env['AWS_ROLE_ARN'] = 'arn:aws:iam::000000000000:role/unit-test';
+        process.env['AWS_ROLE_SESSION_NAME'] = 'unit-test';
+        process.env['STS_ENDPOINT'] = 'https://sts.unit-test.example.com';
+        await awscred.fetchCredentials(r);
+
+        if (!non200ResponseServed) {
+            throw 'The mocked non-200 STS response was never served.';
+        }
+        if (errorBodyParsedAsCredentials) {
+            throw 'A non-200 STS response was parsed as credentials.';
+        }
+        if (returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        }
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            throw 'Credentials must not be cached from a non-200 response.';
+        }
+    } finally {
+        if (originalCredentialPath) {
+            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
+        } else {
+            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
+        }
+        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+        delete process.env['AWS_ROLE_ARN'];
+        delete process.env['AWS_ROLE_SESSION_NAME'];
+        delete process.env['STS_ENDPOINT'];
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            fs.unlinkSync(tempFile);
+        }
+        if (fs.statSync(tokenFile, {throwIfNoEntry: false})) {
+            fs.unlinkSync(tokenFile);
+        }
+    }
+}
+
+function testWriteInvalidCredentials() {
+    printHeader('testWriteInvalidCredentials');
+
+    let accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
+    let secretKey = process.env['AWS_SECRET_ACCESS_KEY'];
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    try {
+        let r = {
+            variables: {
+                cache_instance_credentials_enabled: 1,
+                instance_credential_json: null
+            }
+        };
+        let invalidCredentials = [
+            null,
+            {},
+            {accessKeyId: 'AN_ACCESS_KEY_ID'},
+            {secretAccessKey: 'A_SECRET_ACCESS_KEY'},
+            {accessKeyId: undefined, secretAccessKey: undefined,
+                sessionToken: undefined, expiration: undefined},
+        ];
+        invalidCredentials.forEach(function(credentials) {
+            let threw = false;
+            try {
+                awscred.writeCredentials(r, credentials);
+            } catch (e) {
+                threw = true;
+            }
+            if (!threw) {
+                throw 'writeCredentials accepted invalid credentials: ' +
+                    JSON.stringify(credentials);
+            }
+        });
+        if (r.variables.instance_credential_json !== null) {
+            throw 'Invalid credentials were written to the credentials cache.';
+        }
+    } finally {
+        process.env['AWS_ACCESS_KEY_ID'] = accessKeyId;
+        process.env['AWS_SECRET_ACCESS_KEY'] = secretKey;
+    }
+}
+
 async function test() {
     await testEc2CredentialRetrieval();
     await testEcsCredentialRetrieval();
     await testEKSPodIdentityCredentialRetrieval();
+    await testEc2CredentialRetrievalNon200Response();
+    await testEc2CredentialRetrievalIMDSv1Fallback();
+    await testWebIdentityCredentialRetrievalNon200Response();
     testReadCredentialsWithAccessSecretKeyAndSessionTokenSet();
     testReadCredentialsFromFilePath();
     testReadCredentialsFromNonexistentPath();
     testReadAndWriteCredentialsFromKeyValStore();
+    testWriteInvalidCredentials();
 }
 
 function printHeader(testName) {

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -341,29 +341,23 @@ async function testEc2CredentialRetrieval() {
 
 async function testEKSPodIdentityCredentialRetrieval() {
     printHeader('testEKSPodIdentityCredentialRetrieval');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
-    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
-        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
-    }
-    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
-    }
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var credentialsFile = tempFilePath('eks-happy-credentials-unit-test', '.json');
+    var tokenFile = tempFilePath('eks-happy-token-unit-test', '');
     var testToken = 'A_TOKEN';
-    fs.writeFileSync(tempFile, testToken);
-    process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] = tempFile;
+    fs.writeFileSync(tokenFile, testToken);
+    process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] = tokenFile;
+    var credentialsIssued = false;
     globalThis.ngx.fetch = function(url, options) {
         console.log(' fetching eks pod identity mock credentials');
         if (url === 'http://169.254.170.23/v1/credentials') {
-            if (options && options.headers && options.headers['Authorization'].toString() === testToken) {
+            if (options && options.headers && options.headers['Authorization'] &&
+                options.headers['Authorization'].toString() === testToken) {
                 return Promise.resolve({
                     ok: true,
                     json: function() {
-                        globalThis.credentialsIssued = true;
+                        credentialsIssued = true;
                         return Promise.resolve({
                             AccessKeyId: 'AN_ACCESS_KEY_ID',
                             Expiration: '2017-05-17T15:09:54Z',
@@ -374,22 +368,13 @@ async function testEKSPodIdentityCredentialRetrieval() {
                     },
                 });
             } else {
-                throw 'Invalid token passed: ' + options.headers['Authorization'];
+                throw 'Invalid token passed to the EKS Pod Identity agent';
             }
         } else {
             throw 'Invalid request URL: ' + url;
         }
     };
     var r = {
-        "headersOut": {
-            "Accept-Ranges": "bytes",
-            "Content-Length": 42,
-            "Content-Security-Policy": "block-all-mixed-content",
-            "Content-Type": "text/plain",
-            "X-Amz-Bucket-Region": "us-east-1",
-            "X-Amz-Request-Id": "166539E18A46500A",
-            "X-Xss-Protection": "1; mode=block"
-        },
         log: function(msg) {
             console.log(msg);
         },
@@ -401,14 +386,86 @@ async function testEKSPodIdentityCredentialRetrieval() {
     };
 
     try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = credentialsFile;
         await awscred.fetchCredentials(r);
 
-        if (!globalThis.credentialsIssued) {
+        if (!credentialsIssued) {
             throw 'Did not reach the point where EKS Pod Identity credentials were issued.';
         }
     } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
         delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
-        removeIfExists(tempFile);
+        removeIfExists(credentialsFile);
+        removeIfExists(tokenFile);
+    }
+}
+
+async function testEKSPodIdentityCredentialRetrievalNon200Response() {
+    printHeader('testEKSPodIdentityCredentialRetrievalNon200Response');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var credentialsFile = tempFilePath('eks-non200-credentials-unit-test', '.json');
+    var tokenFile = tempFilePath('eks-non200-token-unit-test', '');
+    var testToken = 'A_TOKEN';
+    fs.writeFileSync(tokenFile, testToken);
+    process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] = tokenFile;
+    var non200ResponseServed = false;
+    var errorBodyParsedAsCredentials = false;
+    var returnedCode = null;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            returnedCode = code;
+        },
+    };
+    globalThis.ngx.fetch = function(url, options) {
+        console.log(' fetching eks pod identity mock error response');
+        if (url === 'http://169.254.170.23/v1/credentials') {
+            if (options && options.headers && options.headers['Authorization'] &&
+                options.headers['Authorization'].toString() === testToken) {
+                non200ResponseServed = true;
+                return Promise.resolve({
+                    ok: false,
+                    status: 503,
+                    json: function() {
+                        // A non-200 body must never be parsed as credentials.
+                        errorBodyParsedAsCredentials = true;
+                        return Promise.resolve({
+                            message: 'Service Unavailable',
+                        });
+                    },
+                });
+            } else {
+                throw 'Invalid token passed to the EKS Pod Identity agent';
+            }
+        } else {
+            throw 'Invalid request URL: ' + url;
+        }
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = credentialsFile;
+        await awscred.fetchCredentials(r);
+
+        if (!non200ResponseServed) {
+            throw 'The mocked non-200 EKS Pod Identity response was never served.';
+        }
+        if (errorBodyParsedAsCredentials) {
+            throw 'A non-200 EKS Pod Identity agent response was parsed as credentials.';
+        }
+        if (returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        }
+        if (fs.statSync(credentialsFile, {throwIfNoEntry: false})) {
+            throw 'Credentials must not be cached from a non-200 response.';
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+        removeIfExists(credentialsFile);
+        removeIfExists(tokenFile);
     }
 }
 
@@ -765,6 +822,7 @@ async function test() {
     await testEc2CredentialRetrieval();
     await testEcsCredentialRetrieval();
     await testEKSPodIdentityCredentialRetrieval();
+    await testEKSPodIdentityCredentialRetrievalNon200Response();
     await testEc2CredentialRetrievalNon200Response();
     await testEc2CredentialRetrievalIMDSv1Fallback();
     await testEc2CredentialRetrievalIMDSv1FallbackOnTokenError();

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -21,6 +21,61 @@ import fs from "fs";
 
 globalThis.ngx = {};
 
+/**
+ * Mock credentials payload in the shape returned by the ECS and EC2 IMDS
+ * credentials endpoints.
+ */
+const MOCK_AWS_CREDS_RESPONSE = {
+    AccessKeyId: 'AN_ACCESS_KEY_ID',
+    Expiration: '2017-05-17T15:09:54Z',
+    RoleArn: 'TASK_ROLE_ARN',
+    SecretAccessKey: 'A_SECRET_ACCESS_KEY',
+    Token: 'A_SECURITY_TOKEN',
+};
+
+const IMDS_TOKEN_URL = 'http://169.254.169.254/latest/api/token';
+const IMDS_SECURITY_CREDS_URL = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
+
+/**
+ * Deletes every provider-selection env var so that each test opts into
+ * exactly one credential provider path.
+ */
+function clearProviderEnv() {
+    delete process.env['AWS_ACCESS_KEY_ID'];
+    delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+    delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+}
+
+/**
+ * Builds a unique temp file path. The prefix must be unique per test so that
+ * a same-millisecond run cannot collide with a file created by another test.
+ */
+function tempFilePath(prefix, extension) {
+    const tempDir = process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp';
+    const uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
+    return `${tempDir}/${prefix}-${uniqId}${extension}`;
+}
+
+/**
+ * Restores an env var to a previously saved value. Deletes the variable when
+ * the saved value is undefined - assigning undefined would re-create the key
+ * with an undefined value, which breaks 'in'-based presence checks.
+ */
+function restoreEnv(name, value) {
+    if (value === undefined) {
+        delete process.env[name];
+    } else {
+        process.env[name] = value;
+    }
+}
+
+function removeIfExists(path) {
+    if (fs.statSync(path, {throwIfNoEntry: false})) {
+        fs.unlinkSync(path);
+    }
+}
+
 
 function testReadCredentialsWithAccessSecretKeyAndSessionTokenSet() {
     printHeader('testReadCredentialsWithAccessSecretKeyAndSessionTokenSet');
@@ -137,15 +192,10 @@ function testReadAndWriteCredentialsFromKeyValStore() {
 
     let accessKeyId = process.env['AWS_ACCESS_KEY_ID'];
     let secretKey = process.env['AWS_SECRET_ACCESS_KEY'];
-    let sessionToken = null;
-    if ('AWS_SESSION_TOKEN' in process.env) {
-        sessionToken = process.env['AWS_SESSION_TOKEN'];
-    }
+    let sessionToken = process.env['AWS_SESSION_TOKEN'];
     delete process.env.AWS_ACCESS_KEY_ID;
     delete process.env.AWS_SECRET_ACCESS_KEY;
-    if ('AWS_SESSION_TOKEN' in process.env) {
-        delete process.env.AWS_SESSION_TOKEN
-    }
+    delete process.env.AWS_SESSION_TOKEN;
     try {
         let r = {
             variables: {
@@ -169,11 +219,9 @@ function testReadAndWriteCredentialsFromKeyValStore() {
             throw 'Credentials do not match expected value';
         }
     } finally {
-        process.env['AWS_ACCESS_KEY_ID'] = accessKeyId;
-        process.env['AWS_SECRET_ACCESS_KEY'] = secretKey;
-        if ('AWS_SESSION_TOKEN' in process.env) {
-            process.env['AWS_SESSION_TOKEN'] = sessionToken
-        }
+        restoreEnv('AWS_ACCESS_KEY_ID', accessKeyId);
+        restoreEnv('AWS_SECRET_ACCESS_KEY', secretKey);
+        restoreEnv('AWS_SESSION_TOKEN', sessionToken);
     }
 }
 
@@ -190,13 +238,7 @@ async function testEcsCredentialRetrieval() {
         return Promise.resolve({
             ok: true,
             json: function () {
-                return Promise.resolve({
-                    AccessKeyId: 'AN_ACCESS_KEY_ID',
-                    Expiration: '2017-05-17T15:09:54Z',
-                    RoleArn: 'TASK_ROLE_ARN',
-                    SecretAccessKey: 'A_SECRET_ACCESS_KEY',
-                    Token: 'A_SECURITY_TOKEN',
-                });
+                return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
             }
         });
     };
@@ -236,14 +278,14 @@ async function testEc2CredentialRetrieval() {
         delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
     }
     globalThis.ngx.fetch = function (url, options) {
-        if (url === 'http://169.254.169.254/latest/api/token' && options && options.method === 'PUT') {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             return Promise.resolve({
                 ok: true,
                 text: function () {
                     return Promise.resolve('A_TOKEN');
                 },
             });
-        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/') {
+        } else if (url === IMDS_SECURITY_CREDS_URL) {
             if (options && options.headers && options.headers['x-aws-ec2-metadata-token'] === 'A_TOKEN') {
                 return Promise.resolve({
                     ok: true,
@@ -254,19 +296,13 @@ async function testEc2CredentialRetrieval() {
             } else {
                 throw 'Invalid token passed: ' + options.headers['x-aws-ec2-metadata-token'];
             }
-        }  else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/A_ROLE_NAME') {
+        }  else if (url === IMDS_SECURITY_CREDS_URL + 'A_ROLE_NAME') {
             if (options && options.headers && options.headers['x-aws-ec2-metadata-token'] === 'A_TOKEN') {
                 return Promise.resolve({
                     ok: true,
                     json: function () {
                         globalThis.credentialsIssued = true;
-                        return Promise.resolve({
-                            AccessKeyId: 'AN_ACCESS_KEY_ID',
-                            Expiration: '2017-05-17T15:09:54Z',
-                            RoleArn: 'TASK_ROLE_ARN',
-                            SecretAccessKey: 'A_SECRET_ACCESS_KEY',
-                            Token: 'A_SECURITY_TOKEN',
-                        });
+                        return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
                     },
                 });
             } else {
@@ -364,31 +400,23 @@ async function testEKSPodIdentityCredentialRetrieval() {
         },
     };
 
-    await awscred.fetchCredentials(r);
+    try {
+        await awscred.fetchCredentials(r);
 
-    if (!globalThis.credentialsIssued) {
-        throw 'Did not reach the point where EKS Pod Identity credentials were issued.';
+        if (!globalThis.credentialsIssued) {
+            throw 'Did not reach the point where EKS Pod Identity credentials were issued.';
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+        removeIfExists(tempFile);
     }
 }
 
 async function testEc2CredentialRetrievalNon200Response() {
     printHeader('testEc2CredentialRetrievalNon200Response');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
-    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
-        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
-    }
-    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
-    }
-    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
-    }
+    clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var tempFile = tempFilePath('credentials-unit-test-ec2-non200', '.json');
     var non200ResponseServed = false;
     var errorBodyParsedAsCredentials = false;
     var returnedCode = null;
@@ -401,21 +429,21 @@ async function testEc2CredentialRetrievalNon200Response() {
         },
     };
     globalThis.ngx.fetch = function (url, options) {
-        if (url === 'http://169.254.169.254/latest/api/token' && options && options.method === 'PUT') {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             return Promise.resolve({
                 ok: true,
                 text: function () {
                     return Promise.resolve('A_TOKEN');
                 },
             });
-        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/') {
+        } else if (url === IMDS_SECURITY_CREDS_URL) {
             return Promise.resolve({
                 ok: true,
                 text: function () {
                     return Promise.resolve('A_ROLE_NAME');
                 },
             });
-        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/A_ROLE_NAME') {
+        } else if (url === IMDS_SECURITY_CREDS_URL + 'A_ROLE_NAME') {
             non200ResponseServed = true;
             return Promise.resolve({
                 ok: false,
@@ -450,35 +478,16 @@ async function testEc2CredentialRetrievalNon200Response() {
             throw 'Credentials must not be cached from a non-200 response.';
         }
     } finally {
-        if (originalCredentialPath) {
-            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
-        } else {
-            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
-        }
-        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tempFile);
-        }
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
     }
 }
 
 async function testEc2CredentialRetrievalIMDSv1Fallback() {
     printHeader('testEc2CredentialRetrievalIMDSv1Fallback');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
-    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
-        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
-    }
-    if ('AWS_WEB_IDENTITY_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
-    }
-    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
-    }
+    clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var tempFile = tempFilePath('credentials-unit-test-imdsv1-fallback', '.json');
     var credentialsIssued = false;
     var r = {
         log: function(msg) {
@@ -491,7 +500,7 @@ async function testEc2CredentialRetrievalIMDSv1Fallback() {
         },
     };
     globalThis.ngx.fetch = function (url, options) {
-        if (url === 'http://169.254.169.254/latest/api/token' && options && options.method === 'PUT') {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             // Simulate an IMDSv1-only metadata service rejecting the token request.
             return Promise.resolve({
                 ok: false,
@@ -501,25 +510,19 @@ async function testEc2CredentialRetrievalIMDSv1Fallback() {
         if (options && options.headers && 'x-aws-ec2-metadata-token' in options.headers) {
             throw 'IMDSv2 token header must not be sent after a rejected token request';
         }
-        if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/') {
+        if (url === IMDS_SECURITY_CREDS_URL) {
             return Promise.resolve({
                 ok: true,
                 text: function () {
                     return Promise.resolve('A_ROLE_NAME');
                 },
             });
-        } else if (url === 'http://169.254.169.254/latest/meta-data/iam/security-credentials/A_ROLE_NAME') {
+        } else if (url === IMDS_SECURITY_CREDS_URL + 'A_ROLE_NAME') {
             return Promise.resolve({
                 ok: true,
                 json: function () {
                     credentialsIssued = true;
-                    return Promise.resolve({
-                        AccessKeyId: 'AN_ACCESS_KEY_ID',
-                        Expiration: '2017-05-17T15:09:54Z',
-                        RoleArn: 'TASK_ROLE_ARN',
-                        SecretAccessKey: 'A_SECRET_ACCESS_KEY',
-                        Token: 'A_SECURITY_TOKEN',
-                    });
+                    return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
                 },
             });
         } else {
@@ -535,33 +538,123 @@ async function testEc2CredentialRetrievalIMDSv1Fallback() {
             throw 'Did not reach the point where EC2 credentials were issued via IMDSv1.';
         }
     } finally {
-        if (originalCredentialPath) {
-            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
+    }
+}
+
+async function testEc2CredentialRetrievalIMDSv1FallbackOnTokenError() {
+    printHeader('testEc2CredentialRetrievalIMDSv1FallbackOnTokenError');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-imdsv1-token-error', '.json');
+    var credentialsIssued = false;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            if (code !== 200) {
+                throw 'Expected 200 status code, got: ' + code;
+            }
+        },
+    };
+    globalThis.ngx.fetch = function (url, options) {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
+            /* Simulate a dropped token response, e.g. the instance's
+               HttpPutResponseHopLimit being exhausted by a container
+               network hop. */
+            return Promise.reject(new Error('connection timed out'));
+        }
+        if (options && options.headers && 'x-aws-ec2-metadata-token' in options.headers) {
+            throw 'IMDSv2 token header must not be sent after a failed token request';
+        }
+        if (url === IMDS_SECURITY_CREDS_URL) {
+            return Promise.resolve({
+                ok: true,
+                text: function () {
+                    return Promise.resolve('A_ROLE_NAME');
+                },
+            });
+        } else if (url === IMDS_SECURITY_CREDS_URL + 'A_ROLE_NAME') {
+            return Promise.resolve({
+                ok: true,
+                json: function () {
+                    credentialsIssued = true;
+                    return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
+                },
+            });
         } else {
-            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
+            throw 'Invalid request URL: ' + url;
+        }
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+
+        if (!credentialsIssued) {
+            throw 'Did not reach the point where EC2 credentials were issued via IMDSv1.';
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
+    }
+}
+
+async function testEc2CredentialRetrievalTokenEndpointTransientError() {
+    printHeader('testEc2CredentialRetrievalTokenEndpointTransientError');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-token-transient', '.json');
+    var imdsv1RequestMade = false;
+    var returnedCode = null;
+    var r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            returnedCode = code;
+        },
+    };
+    globalThis.ngx.fetch = function (url, options) {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
+            /* A transient throttle must fail the fetch rather than silently
+               downgrading to a token-less IMDSv1 request. */
+            return Promise.resolve({
+                ok: false,
+                status: 429,
+            });
+        }
+        imdsv1RequestMade = true;
+        throw 'No request should be made after a transient token endpoint failure: ' + url;
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+
+        if (imdsv1RequestMade) {
+            throw 'A token-less IMDSv1 request was made after a transient token endpoint failure.';
+        }
+        if (returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
         }
         if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tempFile);
+            throw 'Credentials must not be cached after a failed token request.';
         }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
     }
 }
 
 async function testWebIdentityCredentialRetrievalNon200Response() {
     printHeader('testWebIdentityCredentialRetrievalNon200Response');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
-    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
-        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
-    }
-    if ('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE' in process.env) {
-        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
-    }
+    clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
-    var tokenFile = `${tempDir}/web-identity-token-unit-test-${uniqId}`;
+    var tempFile = tempFilePath('credentials-unit-test-web-identity', '.json');
+    var tokenFile = tempFilePath('web-identity-token-unit-test', '');
     fs.writeFileSync(tokenFile, 'A_WEB_IDENTITY_TOKEN');
     var non200ResponseServed = false;
     var errorBodyParsedAsCredentials = false;
@@ -615,21 +708,13 @@ async function testWebIdentityCredentialRetrievalNon200Response() {
             throw 'Credentials must not be cached from a non-200 response.';
         }
     } finally {
-        if (originalCredentialPath) {
-            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
-        } else {
-            delete process.env['AWS_CREDENTIALS_TEMP_FILE'];
-        }
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
         delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
         delete process.env['AWS_ROLE_ARN'];
         delete process.env['AWS_ROLE_SESSION_NAME'];
         delete process.env['STS_ENDPOINT'];
-        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tempFile);
-        }
-        if (fs.statSync(tokenFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tokenFile);
-        }
+        removeIfExists(tempFile);
+        removeIfExists(tokenFile);
     }
 }
 
@@ -671,8 +756,8 @@ function testWriteInvalidCredentials() {
             throw 'Invalid credentials were written to the credentials cache.';
         }
     } finally {
-        process.env['AWS_ACCESS_KEY_ID'] = accessKeyId;
-        process.env['AWS_SECRET_ACCESS_KEY'] = secretKey;
+        restoreEnv('AWS_ACCESS_KEY_ID', accessKeyId);
+        restoreEnv('AWS_SECRET_ACCESS_KEY', secretKey);
     }
 }
 
@@ -682,6 +767,8 @@ async function test() {
     await testEKSPodIdentityCredentialRetrieval();
     await testEc2CredentialRetrievalNon200Response();
     await testEc2CredentialRetrievalIMDSv1Fallback();
+    await testEc2CredentialRetrievalIMDSv1FallbackOnTokenError();
+    await testEc2CredentialRetrievalTokenEndpointTransientError();
     await testWebIdentityCredentialRetrievalNon200Response();
     testReadCredentialsWithAccessSecretKeyAndSessionTokenSet();
     testReadCredentialsFromFilePath();

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -76,6 +76,37 @@ function removeIfExists(path) {
     }
 }
 
+/**
+ * Builds a request stub whose return() throws unless the handler reports 200.
+ */
+function makeExpect200Request() {
+    return {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            if (code !== 200) {
+                throw 'Expected 200 status code, got: ' + code;
+            }
+        },
+    };
+}
+
+/**
+ * Builds a request stub that records the status code passed to return() on
+ * the supplied state object as state.returnedCode.
+ */
+function makeRecordingRequest(state) {
+    return {
+        log: function(msg) {
+            console.log(msg);
+        },
+        return: function(code) {
+            state.returnedCode = code;
+        },
+    };
+}
+
 
 function testReadCredentialsWithAccessSecretKeyAndSessionTokenSet() {
     printHeader('testReadCredentialsWithAccessSecretKeyAndSessionTokenSet');
@@ -125,9 +156,7 @@ function testReadCredentialsFromFilePath() {
     };
 
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var tempFile = tempFilePath('read-credentials-unit-test', '.json');
     var testData = '{"accessKeyId":"A","secretAccessKey":"B",' +
         '"sessionToken":"C","expiration":"2022-02-15T04:49:08Z"}';
     fs.writeFileSync(tempFile, testData);
@@ -149,12 +178,8 @@ function testReadCredentialsFromFilePath() {
             throw 'JSON test data does not match credentials [expiration]';
         }
     } finally {
-        if (originalCredentialPath) {
-            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
-        }
-        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tempFile);
-        }
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
     }
 }
 
@@ -166,9 +191,7 @@ function testReadCredentialsFromNonexistentPath() {
         }
     };
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
-    var tempDir = (process.env['TMPDIR'] ? process.env['TMPDIR'] : '/tmp');
-    var uniqId = `${new Date().getTime()}-${Math.floor(Math.random()*101)}`;
-    var tempFile = `${tempDir}/credentials-unit-test-${uniqId}.json`;
+    var tempFile = tempFilePath('nonexistent-credentials-unit-test', '.json');
 
     try {
         process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
@@ -178,12 +201,8 @@ function testReadCredentialsFromNonexistentPath() {
         }
 
     } finally {
-        if (originalCredentialPath) {
-            process.env['AWS_CREDENTIALS_TEMP_FILE'] = originalCredentialPath;
-        }
-        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
-            fs.unlinkSync(tempFile);
-        }
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
     }
 }
 
@@ -227,13 +246,14 @@ function testReadAndWriteCredentialsFromKeyValStore() {
 
 async function testEcsCredentialRetrieval() {
     printHeader('testEcsCredentialRetrieval');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-ecs-happy', '.json');
+    var recordedUrl = null;
     process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
     globalThis.ngx.fetch = function (url) {
         console.log(' fetching mock credentials');
-        globalThis.recordedUrl = url;
+        recordedUrl = url;
 
         return Promise.resolve({
             ok: true,
@@ -242,41 +262,28 @@ async function testEcsCredentialRetrieval() {
             }
         });
     };
-    var r = {
-        "headersOut" : {
-            "Accept-Ranges": "bytes",
-            "Content-Length": 42,
-            "Content-Security-Policy": "block-all-mixed-content",
-            "Content-Type": "text/plain",
-            "X-Amz-Bucket-Region": "us-east-1",
-            "X-Amz-Request-Id": "166539E18A46500A",
-            "X-Xss-Protection": "1; mode=block"
-        },
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            if (code !== 200) {
-                throw 'Expected 200 status code, got: ' + code;
-            }
-        },
-    };
+    var r = makeExpect200Request();
 
-    await awscred.fetchCredentials(r);
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
 
-    if (globalThis.recordedUrl !== 'http://169.254.170.2/example') {
-        throw `No or wrong ECS credentials fetch URL recorded: ${globalThis.recordedUrl}`;
+        if (recordedUrl !== 'http://169.254.170.2/example') {
+            throw `No or wrong ECS credentials fetch URL recorded: ${recordedUrl}`;
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+        removeIfExists(tempFile);
     }
 }
 
 async function testEc2CredentialRetrieval() {
     printHeader('testEc2CredentialRetrieval');
-    if ('AWS_ACCESS_KEY_ID' in process.env) {
-        delete process.env['AWS_ACCESS_KEY_ID'];
-    }
-    if ('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI' in process.env) {
-        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
-    }
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-ec2-happy', '.json');
+    var credentialsIssued = false;
     globalThis.ngx.fetch = function (url, options) {
         if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             return Promise.resolve({
@@ -294,53 +301,42 @@ async function testEc2CredentialRetrieval() {
                     },
                 });
             } else {
-                throw 'Invalid token passed: ' + options.headers['x-aws-ec2-metadata-token'];
+                throw 'IMDSv2 token missing or invalid on the security credentials request';
             }
         }  else if (url === IMDS_SECURITY_CREDS_URL + 'A_ROLE_NAME') {
             if (options && options.headers && options.headers['x-aws-ec2-metadata-token'] === 'A_TOKEN') {
                 return Promise.resolve({
                     ok: true,
                     json: function () {
-                        globalThis.credentialsIssued = true;
+                        credentialsIssued = true;
                         return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
                     },
                 });
             } else {
-                throw 'Invalid token passed: ' + options.headers['x-aws-ec2-metadata-token'];
+                throw 'IMDSv2 token missing or invalid on the role credentials request';
             }
         } else {
             throw 'Invalid request URL: ' + url;
         }
     };
-    var r = {
-        "headersOut" : {
-            "Accept-Ranges": "bytes",
-            "Content-Length": 42,
-            "Content-Security-Policy": "block-all-mixed-content",
-            "Content-Type": "text/plain",
-            "X-Amz-Bucket-Region": "us-east-1",
-            "X-Amz-Request-Id": "166539E18A46500A",
-            "X-Xss-Protection": "1; mode=block"
-        },
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            if (code !== 200) {
-                throw 'Expected 200 status code, got: ' + code;
-            }
-        },
-    };
+    var r = makeExpect200Request();
 
-    await awscred.fetchCredentials(r);
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
 
-    if (!globalThis.credentialsIssued) {
-        throw 'Did not reach the point where EC2 credentials were issued.';
+        if (!credentialsIssued) {
+            throw 'Did not reach the point where EC2 credentials were issued.';
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        removeIfExists(tempFile);
     }
 }
 
 async function testEKSPodIdentityCredentialRetrieval() {
     printHeader('testEKSPodIdentityCredentialRetrieval');
+    var originalTokenFile = process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
     clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var credentialsFile = tempFilePath('eks-happy-credentials-unit-test', '.json');
@@ -374,16 +370,7 @@ async function testEKSPodIdentityCredentialRetrieval() {
             throw 'Invalid request URL: ' + url;
         }
     };
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            if (code !== 200) {
-                throw 'Expected 200 status code, got: ' + code;
-            }
-        },
-    };
+    var r = makeExpect200Request();
 
     try {
         process.env['AWS_CREDENTIALS_TEMP_FILE'] = credentialsFile;
@@ -394,7 +381,7 @@ async function testEKSPodIdentityCredentialRetrieval() {
         }
     } finally {
         restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
-        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+        restoreEnv('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE', originalTokenFile);
         removeIfExists(credentialsFile);
         removeIfExists(tokenFile);
     }
@@ -402,6 +389,7 @@ async function testEKSPodIdentityCredentialRetrieval() {
 
 async function testEKSPodIdentityCredentialRetrievalNon200Response() {
     printHeader('testEKSPodIdentityCredentialRetrievalNon200Response');
+    var originalTokenFile = process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
     clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var credentialsFile = tempFilePath('eks-non200-credentials-unit-test', '.json');
@@ -411,15 +399,8 @@ async function testEKSPodIdentityCredentialRetrievalNon200Response() {
     process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'] = tokenFile;
     var non200ResponseServed = false;
     var errorBodyParsedAsCredentials = false;
-    var returnedCode = null;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            returnedCode = code;
-        },
-    };
+    var state = {returnedCode: null};
+    var r = makeRecordingRequest(state);
     globalThis.ngx.fetch = function(url, options) {
         console.log(' fetching eks pod identity mock error response');
         if (url === 'http://169.254.170.23/v1/credentials') {
@@ -455,15 +436,15 @@ async function testEKSPodIdentityCredentialRetrievalNon200Response() {
         if (errorBodyParsedAsCredentials) {
             throw 'A non-200 EKS Pod Identity agent response was parsed as credentials.';
         }
-        if (returnedCode !== 500) {
-            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        if (state.returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + state.returnedCode;
         }
         if (fs.statSync(credentialsFile, {throwIfNoEntry: false})) {
             throw 'Credentials must not be cached from a non-200 response.';
         }
     } finally {
         restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
-        delete process.env['AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE'];
+        restoreEnv('AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE', originalTokenFile);
         removeIfExists(credentialsFile);
         removeIfExists(tokenFile);
     }
@@ -476,15 +457,8 @@ async function testEc2CredentialRetrievalNon200Response() {
     var tempFile = tempFilePath('credentials-unit-test-ec2-non200', '.json');
     var non200ResponseServed = false;
     var errorBodyParsedAsCredentials = false;
-    var returnedCode = null;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            returnedCode = code;
-        },
-    };
+    var state = {returnedCode: null};
+    var r = makeRecordingRequest(state);
     globalThis.ngx.fetch = function (url, options) {
         if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             return Promise.resolve({
@@ -528,8 +502,8 @@ async function testEc2CredentialRetrievalNon200Response() {
         if (errorBodyParsedAsCredentials) {
             throw 'A non-200 EC2 metadata response was parsed as credentials.';
         }
-        if (returnedCode !== 500) {
-            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        if (state.returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + state.returnedCode;
         }
         if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
             throw 'Credentials must not be cached from a non-200 response.';
@@ -546,16 +520,7 @@ async function testEc2CredentialRetrievalIMDSv1Fallback() {
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-imdsv1-fallback', '.json');
     var credentialsIssued = false;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            if (code !== 200) {
-                throw 'Expected 200 status code, got: ' + code;
-            }
-        },
-    };
+    var r = makeExpect200Request();
     globalThis.ngx.fetch = function (url, options) {
         if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             // Simulate an IMDSv1-only metadata service rejecting the token request.
@@ -606,16 +571,7 @@ async function testEc2CredentialRetrievalIMDSv1FallbackOnTokenError() {
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-imdsv1-token-error', '.json');
     var credentialsIssued = false;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            if (code !== 200) {
-                throw 'Expected 200 status code, got: ' + code;
-            }
-        },
-    };
+    var r = makeExpect200Request();
     globalThis.ngx.fetch = function (url, options) {
         if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             /* Simulate a dropped token response, e.g. the instance's
@@ -665,15 +621,8 @@ async function testEc2CredentialRetrievalTokenEndpointTransientError() {
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-token-transient', '.json');
     var imdsv1RequestMade = false;
-    var returnedCode = null;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            returnedCode = code;
-        },
-    };
+    var state = {returnedCode: null};
+    var r = makeRecordingRequest(state);
     globalThis.ngx.fetch = function (url, options) {
         if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
             /* A transient throttle must fail the fetch rather than silently
@@ -694,8 +643,8 @@ async function testEc2CredentialRetrievalTokenEndpointTransientError() {
         if (imdsv1RequestMade) {
             throw 'A token-less IMDSv1 request was made after a transient token endpoint failure.';
         }
-        if (returnedCode !== 500) {
-            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        if (state.returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + state.returnedCode;
         }
         if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
             throw 'Credentials must not be cached after a failed token request.';
@@ -706,8 +655,54 @@ async function testEc2CredentialRetrievalTokenEndpointTransientError() {
     }
 }
 
+async function testEc2CredentialRetrievalIMDSv1FallbackDisabled() {
+    printHeader('testEc2CredentialRetrievalIMDSv1FallbackDisabled');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var originalV1Disabled = process.env['AWS_EC2_METADATA_V1_DISABLED'];
+    var tempFile = tempFilePath('credentials-unit-test-v1-disabled', '.json');
+    var imdsv1RequestMade = false;
+    var state = {returnedCode: null};
+    var r = makeRecordingRequest(state);
+    globalThis.ngx.fetch = function (url, options) {
+        if (url === IMDS_TOKEN_URL && options && options.method === 'PUT') {
+            /* A status that would normally trigger the IMDSv1 fallback. */
+            return Promise.resolve({
+                ok: false,
+                status: 404,
+            });
+        }
+        imdsv1RequestMade = true;
+        throw 'No request should be made when the IMDSv1 fallback is disabled: ' + url;
+    };
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        process.env['AWS_EC2_METADATA_V1_DISABLED'] = 'true';
+        await awscred.fetchCredentials(r);
+
+        if (imdsv1RequestMade) {
+            throw 'A token-less IMDSv1 request was made although the fallback is disabled.';
+        }
+        if (state.returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + state.returnedCode;
+        }
+        if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
+            throw 'Credentials must not be cached after a failed token request.';
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        restoreEnv('AWS_EC2_METADATA_V1_DISABLED', originalV1Disabled);
+        removeIfExists(tempFile);
+    }
+}
+
 async function testWebIdentityCredentialRetrievalNon200Response() {
     printHeader('testWebIdentityCredentialRetrievalNon200Response');
+    var originalTokenFile = process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
+    var originalRoleArn = process.env['AWS_ROLE_ARN'];
+    var originalRoleSessionName = process.env['AWS_ROLE_SESSION_NAME'];
+    var originalStsEndpoint = process.env['STS_ENDPOINT'];
     clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-web-identity', '.json');
@@ -715,15 +710,8 @@ async function testWebIdentityCredentialRetrievalNon200Response() {
     fs.writeFileSync(tokenFile, 'A_WEB_IDENTITY_TOKEN');
     var non200ResponseServed = false;
     var errorBodyParsedAsCredentials = false;
-    var returnedCode = null;
-    var r = {
-        log: function(msg) {
-            console.log(msg);
-        },
-        return: function(code) {
-            returnedCode = code;
-        },
-    };
+    var state = {returnedCode: null};
+    var r = makeRecordingRequest(state);
     globalThis.ngx.fetch = function (url) {
         if (url.startsWith('https://sts.unit-test.example.com?')) {
             non200ResponseServed = true;
@@ -758,18 +746,18 @@ async function testWebIdentityCredentialRetrievalNon200Response() {
         if (errorBodyParsedAsCredentials) {
             throw 'A non-200 STS response was parsed as credentials.';
         }
-        if (returnedCode !== 500) {
-            throw 'Expected the credentials fetch to fail with 500, got: ' + returnedCode;
+        if (state.returnedCode !== 500) {
+            throw 'Expected the credentials fetch to fail with 500, got: ' + state.returnedCode;
         }
         if (fs.statSync(tempFile, {throwIfNoEntry: false})) {
             throw 'Credentials must not be cached from a non-200 response.';
         }
     } finally {
         restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
-        delete process.env['AWS_WEB_IDENTITY_TOKEN_FILE'];
-        delete process.env['AWS_ROLE_ARN'];
-        delete process.env['AWS_ROLE_SESSION_NAME'];
-        delete process.env['STS_ENDPOINT'];
+        restoreEnv('AWS_WEB_IDENTITY_TOKEN_FILE', originalTokenFile);
+        restoreEnv('AWS_ROLE_ARN', originalRoleArn);
+        restoreEnv('AWS_ROLE_SESSION_NAME', originalRoleSessionName);
+        restoreEnv('STS_ENDPOINT', originalStsEndpoint);
         removeIfExists(tempFile);
         removeIfExists(tokenFile);
     }
@@ -827,6 +815,7 @@ async function test() {
     await testEc2CredentialRetrievalIMDSv1Fallback();
     await testEc2CredentialRetrievalIMDSv1FallbackOnTokenError();
     await testEc2CredentialRetrievalTokenEndpointTransientError();
+    await testEc2CredentialRetrievalIMDSv1FallbackDisabled();
     await testWebIdentityCredentialRetrievalNon200Response();
     testReadCredentialsWithAccessSecretKeyAndSessionTokenSet();
     testReadCredentialsFromFilePath();


### PR DESCRIPTION
Hardens every dynamic credential provider path against non-200 responses being parsed and cached as AWS credentials, and fixes related defects found by a deep review of this code area.

## Credit

This supersedes and incorporates #538 by @tomknee-accelins, who identified and fixed the bug class on the EKS Pod Identity path — their fix and test are included here (commit `66182c9`) with co-author credit. Thank you!

## Changes

- **`_fetchEKSPodIdentityCredentials`** (from #538): throws on non-200 agent responses instead of parsing the error body as credentials.
- **`_fetchEC2RoleCredentials`**: the IMDS role-name and credentials fetches throw on non-200 (realistic with IMDS-compatible proxies like kube2iam/kiam). A failed IMDSv2 token request now falls back to IMDSv1 the way AWS SDKs do: network errors and 403/404/405 downgrade (logged), while other statuses (throttling, 5xx) fail fast with the token endpoint's status instead of sending a doomed tokenless request that would misattribute the error.
- **`_fetchWebIdentityCredentials`**: non-200 STS responses previously caused a TypeError logged as `{}`; they now throw with the status and error body (capped at 1KB). STS query parameters are percent-encoded — IAM session names may legally contain `+`, and non-JWT web identity tokens may contain query metacharacters.
- **`writeCredentials`**: requires `accessKeyId` and `secretAccessKey` instead of mere truthiness, closing the bug class at the choke point all fetchers flow through. Field values are deliberately not logged.
- Guard messages are provider-distinct so operators can tell from logs which credential path failed.

## Tests

Eight new/rewritten unit tests covering: EKS non-200, EC2 non-200, EC2 IMDSv1 fallback (rejected token PUT and network-error token PUT), EC2 fail-fast on 429, STS non-200, and writeCredentials shape validation — each with positive served-response assertions and no-cache-write invariants. Shared setup/teardown helpers eliminate a same-millisecond temp-file collision flake (reproducible ~1-3% per run) that has been intermittently failing CI, and two env-var restore bugs in pre-existing tests are fixed.

Both `awscredentials_test.js` and `s3gateway_test.js` suites pass 10/10 repeat runs in the gateway image.

## Additional hardening (review pass 3)

- Shared `_checkResponseOk()` helper replaces the five per-callsite guards.
- Standard AWS SDK setting `AWS_EC2_METADATA_V1_DISABLED=true` disables the IMDSv1 fallback so credential retrieval fails closed (documented in `getting_started.md` along with the fallback's behavior and timeout cost).
- IMDS failures after a fallback now name the token failure that caused the downgrade instead of surfacing a bare 401.
- Provider fetch errors log `${e}` instead of `JSON.stringify(e)` (which njs renders as `{}` for Error objects).
- Web identity / EKS token file contents are trimmed — a trailing newline from `echo`-provisioned token files previously broke every refresh (`%0A` at STS, invalid header value at the EKS agent).
