### PR TITLE
fix: only treat dots in the final path segment as file extensions

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -398,8 +398,7 @@ function trailslashControl(r) {
         // consider the uri without query params or anchors
         const path = r.variables.uri_path.split(/[?#]/)[0];
 
-        const hasExtension = /(\/[^\/]*)*(\/[^\/]*\.[^.\/]*)$/;
-        if (!hasExtension.test(path)  && !_isDirectory(path)){
+        if (!_hasExtension(path)  && !_isDirectory(path)){
             return r.internalRedirect("@trailslash");
         }
     }
@@ -518,6 +517,20 @@ function _isDirectory(path) {
 }
 
 /**
+ * Determines if the last segment of a path contains a file extension. Only
+ * the final segment is considered, so a dot in an intermediate directory
+ * (e.g. /foo.foo/bar) does not count as an extension.
+ *
+ * @param path {string} path to parse
+ * @returns {boolean} true if the last path segment has an extension
+ * @private
+ */
+function _hasExtension(path) {
+    const hasExtension = /(\/[^\/]*)*(\/[^\/]*\.[^.\/]*)$/;
+    return hasExtension.test(path);
+}
+
+/**
  * Checks to see if the given environment variable is present. If not, an error
  * is thrown.
  * @param envVarName {string} environment variable to check for
@@ -546,5 +559,6 @@ export default {
     _s3ReqParamsForSigV4,
     _encodeURIComponent,
     _escapeURIPath,
+    _hasExtension,
     _isHeaderToBeStripped
 };

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -396,9 +396,20 @@ function trailslashControl(r) {
     if (APPEND_SLASH) {
         // For the purposes of understanding whether this is a directory,
         // consider the uri without query params or anchors
-        const path = r.variables.uri_path.split(/[?#]/)[0];
+        let path = r.variables.uri_path.split(/[?#]/)[0];
 
-        if (!_hasExtension(path)  && !_isDirectory(path)){
+        // Classify the decoded path so that percent-encoded dots (%2E) are
+        // visible to the extension check, matching the decoded $uri that the
+        // @trailslash rewrite redirects to. If decoding fails (e.g. invalid
+        // UTF-8 sequences that nginx passes through), classify the raw path
+        // rather than letting a URIError turn the 404 into a 500.
+        try {
+            path = decodeURIComponent(path);
+        } catch (e) {
+            // fall back to the raw path
+        }
+
+        if (!_hasExtension(path) && !_isDirectory(path)) {
             return r.internalRedirect("@trailslash");
         }
     }
@@ -517,17 +528,19 @@ function _isDirectory(path) {
 }
 
 /**
- * Determines if the last segment of a path contains a file extension. Only
- * the final segment is considered, so a dot in an intermediate directory
- * (e.g. /foo.foo/bar) does not count as an extension.
+ * Determines if the final segment of a path contains a dot, which the
+ * gateway treats as a file extension. Only the final segment is considered,
+ * so a dot in an intermediate directory (e.g. /foo.foo/bar) does not count
+ * as an extension. Dotfiles (/.hidden) and segments with a trailing dot
+ * (/foo.) do count as having an extension, and the final segment must be
+ * preceded by a slash (a bare 'foo.jpg' returns false).
  *
  * @param path {string} path to parse
  * @returns {boolean} true if the last path segment has an extension
  * @private
  */
 function _hasExtension(path) {
-    const hasExtension = /\/[^\/]*\.[^.\/]*$/;
-    return hasExtension.test(path);
+    return /\/[^\/]*\.[^.\/]*$/.test(path);
 }
 
 /**

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -398,7 +398,7 @@ function trailslashControl(r) {
         // consider the uri without query params or anchors
         const path = r.variables.uri_path.split(/[?#]/)[0];
 
-        const hasExtension = /\/[^.\/]+\.[^.]+$/;
+        const hasExtension = /(\/[^\/]*)*(\/[^\/]*\.[^.\/]*)$/;
         if (!hasExtension.test(path)  && !_isDirectory(path)){
             return r.internalRedirect("@trailslash");
         }

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -526,7 +526,7 @@ function _isDirectory(path) {
  * @private
  */
 function _hasExtension(path) {
-    const hasExtension = /(\/[^\/]*)*(\/[^\/]*\.[^.\/]*)$/;
+    const hasExtension = /\/[^\/]*\.[^.\/]*$/;
     return hasExtension.test(path);
 }
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -136,7 +136,9 @@ Default of "index.html" can be edited in `s3gateway.js`.
 It will also redirect `/some/path` to `/some/path/` when S3 returns 404 on 
 `/some/path` if `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is set. `path` has to 
 look like a possible directory, it must not start with a `.` and not have an 
-extension.  
+extension. Only the final path segment is checked for an extension, so a dot 
+in an intermediate directory (e.g. `/dir.name/file`) does not prevent the 
+redirect.  
 
 ### Hosting a Bucket as a Subfolder on an ALB
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -138,7 +138,8 @@ It will also redirect `/some/path` to `/some/path/` when S3 returns 404 on
 look like a possible directory, it must not start with a `.` and not have an 
 extension. Only the final path segment is checked for an extension, so a dot 
 in an intermediate directory (e.g. `/dir.name/file`) does not prevent the 
-redirect.  
+redirect. A final segment that begins or ends with a dot (e.g. `/.hidden`, 
+`/reports.`) is treated as having an extension and is not redirected.  
 
 ### Hosting a Bucket as a Subfolder on an ALB
 

--- a/test.sh
+++ b/test.sh
@@ -374,6 +374,7 @@ runUnitTestWithOutSessionToken() {
         -e "S3_SERVER_PORT=443"               \
         -e "S3_REGION=test-1"                 \
         -e "AWS_SIGS_VERSION=4"               \
+        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
         --entrypoint /usr/bin/njs             \
         nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
     else
@@ -394,6 +395,7 @@ runUnitTestWithOutSessionToken() {
         -e "S3_SERVER_PORT=443"               \
         -e "S3_REGION=test-1"                 \
         -e "AWS_SIGS_VERSION=4"               \
+        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
         --entrypoint /usr/bin/njs             \
         nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
   fi
@@ -422,6 +424,7 @@ runUnitTestWithSessionToken() {
         -e "S3_SERVER_PORT=443"               \
         -e "S3_REGION=test-1"                 \
         -e "AWS_SIGS_VERSION=4"               \
+        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
         --entrypoint /usr/bin/njs             \
         nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
     else
@@ -443,6 +446,7 @@ runUnitTestWithSessionToken() {
         -e "S3_SERVER_PORT=443"               \
         -e "S3_REGION=test-1"                 \
         -e "AWS_SIGS_VERSION=4"               \
+        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
         --entrypoint /usr/bin/njs             \
         nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
   fi

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -284,6 +284,49 @@ function testHasExtension() {
     });
 }
 
+function testTrailslashControl() {
+    printHeader('testTrailslashControl');
+
+    // Requires APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true in the test
+    // environment so that the redirect branch is reachable.
+    const testCases = [
+        // Extension-less paths that look like possible directories get the
+        // append-slash redirect, even under a dotted directory (issue #522)
+        ['/dir.name/file', '@trailslash'],
+        ['/foo/bar', '@trailslash'],
+        // Query params and anchors are ignored for classification
+        ['/foo/bar?baz=1', '@trailslash'],
+        // Percent-encoded dots are decoded before classification, so this
+        // is a file, not a possible directory
+        ['/dir/file%2Ejpg', '@error404'],
+        // Undecodable sequences must not throw; the raw path is classified
+        ['/foo%C3', '@trailslash'],
+        ['/file.jpg', '@error404'],
+        // Directories fall through to the 404 handler
+        ['/dir/', '@error404']
+    ];
+
+    testCases.forEach(function(testCase) {
+        const uriPath = testCase[0];
+        const expected = testCase[1];
+        let redirectedTo = null;
+        const r = {
+            variables: {
+                uri_path: uriPath
+            },
+            internalRedirect: function(target) {
+                redirectedTo = target;
+            }
+        };
+        console.log(`  ## testTrailslashControl: ${uriPath} => ${expected}`);
+        s3gateway.trailslashControl(r);
+        if (redirectedTo !== expected) {
+            throw `Path [${uriPath}] should have been redirected to ` +
+                `[${expected}] but was [${redirectedTo}]`;
+        }
+    });
+}
+
 function testEscapeURIPathPreservesDoubleSlashes() {
     printHeader('testEscapeURIPathPreservesDoubleSlashes');
     var doubleSlashed = '/testbucketer2/foo3//bar3/somedir/license';
@@ -426,6 +469,7 @@ async function test() {
     testEditHeaders();
     testEditHeadersHeadDirectory();
     testHasExtension();
+    testTrailslashControl();
     testEscapeURIPathPreservesDoubleSlashes();
     await testEcsCredentialRetrieval();
     await testEc2CredentialRetrieval();

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -244,6 +244,46 @@ function testIsHeaderToBeAllowed() {
     }
 }
 
+function testHasExtension() {
+    printHeader('testHasExtension');
+
+    // Only a dot in the final path segment counts as an extension. Dots in
+    // intermediate directories must not suppress the trailing-slash redirect
+    // (see issue #522).
+    const pathsWithExtension = [
+        '/ramen.jpg',
+        '/a/c/ramen.jpg',
+        '/foo.foo/bar.baz',
+        '/foo/bar.tar.gz',
+        // Dotfiles and trailing dots are treated as having an extension
+        '/.hidden',
+        '/foo.'
+    ];
+    const pathsWithoutExtension = [
+        '/',
+        '/foo',
+        '/foo/bar',
+        '/foo.foo/',
+        '/foo.foo/bar',
+        '/foo.foo/bar/baz'
+    ];
+
+    pathsWithExtension.forEach(function(path) {
+        console.log(`  ## testHasExtension: ${path}`);
+        if (!s3gateway._hasExtension(path)) {
+            throw `Path [${path}] should be detected as having an extension`;
+        }
+    });
+
+    pathsWithoutExtension.forEach(function(path) {
+        console.log(`  ## testHasExtension: ${path}`);
+        if (s3gateway._hasExtension(path)) {
+            throw `Path [${path}] should not be detected as having ` +
+                'an extension';
+        }
+    });
+}
+
 function testEscapeURIPathPreservesDoubleSlashes() {
     printHeader('testEscapeURIPathPreservesDoubleSlashes');
     var doubleSlashed = '/testbucketer2/foo3//bar3/somedir/license';
@@ -385,6 +425,7 @@ async function test() {
     testIsHeaderToBeStripped();
     testEditHeaders();
     testEditHeadersHeadDirectory();
+    testHasExtension();
     testEscapeURIPathPreservesDoubleSlashes();
     await testEcsCredentialRetrieval();
     await testEc2CredentialRetrieval();


### PR DESCRIPTION
### Proposed changes

Fixes #522. Supersedes #523 — it includes @fburato's original fix as its first commit (authorship preserved), plus follow-up hardening found while reviewing that change.

When `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is enabled, the `hasExtension` check in `trailslashControl` treated a dot anywhere after the last dot-free directory as an extension, so paths under a dotted directory (e.g. `/foo.foo/bar`) never received the append-slash redirect. This PR restricts extension detection to the final path segment, and layers three follow-ups on top:

1. **`fix: prevent hasExtension matching non terminal sub-paths`** (@fburato, from #523) — replaces the regex so only the final segment is considered. Also corrects two latent misclassifications: multi-dot filenames (`/foo.tar.gz`) and dotfiles (`/.hidden`) are now treated as files, matching the documented behavior.
2. **`test: cover extension detection in trailslashControl`** — extracts the regex into a testable `_hasExtension` helper (exported like the other test-only functions) and adds a 12-case truth table derived from #522's expectation matrix.
3. **`perf: remove redundant group from extension-detection regex`** — the leading `(\/[^\/]*)*` group matched an unanchored prefix and contributed nothing (verified exhaustively over all path-like strings up to length 9), but produced O(n²) backtracking: ~230 ms per match for an 8 KB request line, reachable unauthenticated on every S3 404 since `uri_path` derives from the raw `$request_uri`. The simplified regex is linear.
4. **`fix: classify decoded uri_path in trailslashControl`** — the `@trailslash` rewrite redirects using the decoded `$uri`, but classification ran against the raw percent-encoded path, so a missing `/dir/file%2Ejpg` got a spurious 302 to `/dir/file.jpg/` instead of a 404. The path is now decoded before classification, guarded with try/catch because njs `decodeURIComponent` throws `URIError` on invalid sequences (e.g. `/foo%C3`) that nginx passes through — an unguarded decode would turn those 404s into 500s. Unit tests now drive `trailslashControl` end to end (with `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true` added to the unit-test environment in `test.sh`), and `docs/getting_started.md` documents the final-segment and dotfile/trailing-dot semantics.

Behavior changes for operators: paths under dotted directories now redirect as expected (the #522 fix); dotfiles, trailing-dot segments, multi-dot filenames, and percent-encoded-dot filenames now return 404 instead of a bogus append-slash 302.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
