### PR TITLE
fix: harden trailslash path decoding and add CORS to @trailslash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,241 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository.
+
+## Project overview
+
+NGINX S3 Gateway configures NGINX (OSS or Plus) as an authenticating, caching
+proxy in front of S3-compatible object stores. There is no application server:
+the "code" is NGINX configuration plus njs (NGINX JavaScript) modules, packaged
+as Docker images.
+
+## Layout
+
+- `common/etc/nginx/include/` — the njs modules (`s3gateway.js`, `awssig2.js`,
+  `awssig4.js`, `awscredentials.js`, `utils.js`). Most logic changes happen here.
+- `common/etc/nginx/templates/` — NGINX config templates that bind to the njs
+  exports (`js_set`, `js_content`, `js_body_filter`).
+- `common/docker-entrypoint.d/` — container entrypoint shell scripts.
+- `oss/`, `plus/` — NGINX config specific to OSS and Plus flavors; keep the two
+  functionally equivalent when changing one.
+- `test/unit/` — njs unit tests; `test/integration/` — bash integration tests.
+- `Dockerfile.oss`, `Dockerfile.plus`, `Dockerfile.latest-njs`,
+  `Dockerfile.unprivileged` — base images and variants.
+- `examples/`, `deployments/`, `docs/` — usage examples, deploy templates, docs.
+
+## Build, test, lint
+
+The `GNUmakefile` (GNU Make 4.x) is the **only supported interface** for build
+and test workflows. The legacy `test.sh` script still exists underneath, but we
+are migrating away from it — never invoke or recommend `./test.sh` directly.
+Run `make help` for the full target list, `make check-tools` to verify
+prerequisites (docker, docker compose, curl, mc/MinIO client).
+
+- `make build` — build the gateway image (`NGINX_TYPE=oss` default, or `plus`).
+- `make test` — build, then run the full unit + integration suite.
+- `make retest` — rerun tests against the already-built image (fast iteration,
+  but see the staleness warning below).
+- `make test-matrix` — reproduce the CI matrix locally.
+- `make lint` — checkmake + shellcheck.
+- `make docs` — generate JSDoc reference documentation.
+
+Notes:
+
+- **Staleness warning**: unit tests import the njs modules baked into the image
+  (`/etc/nginx/include/`), not the working tree — only `test/unit/` is
+  bind-mounted. After editing `common/etc/nginx/include/*.js`, run `make test`
+  (rebuilds first); `make retest` would test the stale copy.
+- Integration tests spin up MinIO via `test/docker-compose.yaml` (compose
+  project `ngt`) and hit the gateway on `localhost:8989`.
+- `S3_STYLE` (`virtual` or `virtual-v2`) selects the S3 addressing style under
+  test; CI runs both.
+- The `latest-njs` variant runs the njs CLI with `-m` instead of `-t module`
+  (transitional flag fork while njs migrates its CLI).
+- NGINX Plus builds/tests require repo certs in `plus/etc/ssl/nginx/` and a
+  `license.jwt` — skip Plus targets if you don't have them.
+
+## JavaScript rules (njs, not Node.js)
+
+The modules run on the **njs engine**: ECMAScript 5.1 strict mode plus a
+limited set of ES6+ extensions (see
+<https://nginx.org/en/docs/njs/compatibility.html>). It is NOT Node.js: there
+are no npm packages at runtime, no Node stdlib, and no JS-owned event loop.
+Everything in `package.json` is dev-only tooling (jsdoc, njs-types).
+
+Language subset — allowed (all in use today):
+
+- `const`/`let` (never `var` in modules; `const` preferred, `let` only when
+  reassigned), function declarations, `async`/`await` (never top-level),
+  Promises, template literals, `for (let i = 0; ...)` and `for ... in` loops.
+
+Forbidden (unsupported by the njs engine, or unused by project convention):
+
+- `class`, destructuring, spread, default parameters, generators, `for...of`,
+  `Map`/`Set`, optional chaining `?.`, nullish coalescing `??`, `.then()`
+  chains, arrow functions (one legacy arrow exists in `s3gateway.js` — do not
+  add more).
+
+Module structure, top to bottom:
+
+1. Apache-2.0 license header (`Copyright 2023 F5, Inc.` form).
+2. `@module` / `@alias` JSDoc block.
+3. `@typedef` blocks for shared structures.
+4. ES `import`s of first-party modules — relative path with `.js` extension,
+   **default imports only** (njs rejects named and namespace imports).
+5. `const mod_x = require('...')` for njs built-ins (`crypto`, `fs`).
+6. Documented module-level constants.
+7. Functions.
+8. A single `export default { ... }` map at the bottom of the file.
+
+Other rules:
+
+- Configuration is read from `process.env['UPPER_SNAKE']` (bracket notation)
+  into module-level `const`s **at import time**. This has a direct testing
+  consequence — see "Unit testing rules". `ngx` is used only for `ngx.fetch`.
+- **`console.log` is not allowed in gateway modules.** All logging goes through
+  `utils.debug_log(r, msg)`, which guards on the `DEBUG` env var and on
+  `"log" in r` so stub requests without a log method stay safe. `console.log`
+  is permitted only in `test/unit/` files, where it is the test-output
+  mechanism.
+- **No magic string literals**: extract repeated or meaningful literals (e.g.
+  `index.html`) into documented module-level constants. Variable names carry
+  units where relevant (e.g. `maxValidityOffsetMs`).
+- Comments explain **why**, not what, and link to the relevant AWS
+  documentation for protocol/signing behavior. No lingering TODOs: replace a
+  TODO with an explanation plus a tracking issue, and delete TODOs your change
+  resolves.
+- Naming: camelCase functions and locals; `_`-prefixed + `@private` for
+  internal functions; UPPER_SNAKE module constants; AWS spec names (`kSecret`,
+  `kDate`, `kSigning`...) are correct in signing code. `debug_log` is a
+  grandfathered snake_case exception.
+- Errors are **thrown as strings** (`throw 'message'` or a template literal),
+  never `new Error()` — consistent project-wide.
+- Formatting: 4-space indent, single-quoted strings, double-quoted import
+  specifiers, semicolons. No linter enforces JS style — review does.
+- NGINX config binds to exported names (e.g. `js_set $s3auth s3gateway.s3auth`
+  in `common/etc/nginx/templates/default.conf.template`), so renaming or
+  removing an exported key is a breaking config change — update the templates
+  in lockstep.
+- **Duck-typed environment guards**: production code must tolerate stub request
+  objects by feature-testing (`"variables" in r`, `"log" in r`,
+  `"headersOut" in r`) instead of assuming a full nginx request. The same
+  guards distinguish NGINX Plus (keyval store) from OSS, and production from
+  unit tests — do not break them.
+
+## JSDoc conventions
+
+Structures and njs types are defined and referenced through JSDoc; docs are
+generated with `make docs` (config in `jsdoc/conf.json`).
+
+- Every exported function gets a JSDoc block. House `@param` style is
+  **name-first**: `@param r {NginxHTTPRequest} HTTP request object` — not the
+  mainstream `{type} name` order. Use `@returns` (plural), and `@private` on
+  internal functions.
+- Shared structures are defined once as `@typedef {Object} Name` with
+  `@property {type} field - description` lines, placed right after the
+  `@module` block (existing examples: `Credentials` in `awscredentials.js`,
+  `S3ReqParams` in `s3gateway.js`). Reference them by bare name (e.g.
+  `{Credentials}`) from any module — JSDoc processes all files in one pass.
+- njs runtime types are referenced by bare name (`NginxHTTPRequest`,
+  `NjsStringOrBuffer`, `Response`...). They resolve because `jsdoc/conf.json`
+  includes `./node_modules/njs-types` via the `better-docs/typescript` plugin.
+  Do not add `/// <reference>` directives or a tsconfig.
+- Module headers pair `@module <lowercase>` with `@alias <PascalCase>`
+  (`utils`/`Utils`, `awssig4`/`AwsSig4`, ...).
+- Params that nginx requires but the function ignores: underscore-prefix them
+  and document as `(not used, but required for NGINX configuration)`.
+- Use `@see {@link <url> | Title}` for AWS specification references.
+
+## Unit testing rules
+
+Unit tests run under the **njs CLI** (`/usr/bin/njs`) inside the built image.
+Per the nginx docs, nginx objects are not available in the CLI: there is no
+`ngx`, no request object `r`, and no nginx variables. Everything
+nginx-provided must be hand-mocked.
+
+- **Run tests only through make** (`make test` / `make retest`). Under the
+  hood each test file currently runs via
+  `docker run --entrypoint /usr/bin/njs nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/<file>`
+  with a fixed env list (`AWS_ACCESS_KEY_ID=unit_test`,
+  `S3_BUCKET_NAME=unit_test`, `DEBUG=true`, `S3_REGION=test-1`,
+  `AWS_SIGS_VERSION=4`, ...). Every suite runs twice — with and without
+  `AWS_SESSION_TOKEN` — so tests must pass in both modes, branching with
+  `if ('AWS_SESSION_TOKEN' in process.env)` where behavior differs.
+- **Mock `ngx` via `globalThis`**: declare `globalThis.ngx = {};` at the top of
+  the file, then assign `globalThis.ngx.fetch = function (url, options) {...}`
+  per test, returning Response-alikes
+  (`{ok: true, status: 200, json/text: function() { return Promise.resolve(...); }}`).
+  Unexpected URLs or arguments should `throw` a string — the throw is the
+  assertion. Record observations in closure variables; do not write them onto
+  `globalThis` (an older `s3gateway_test.js` style — don't copy it).
+- **Mock `r` as a plain object literal** containing only the fields the code
+  under test touches (`variables`, `headersIn`, `headersOut`, `uri`, `method`,
+  ...). Attach behavior after construction:
+  `r.log = function(msg) { console.log(msg); }` — required whenever the code
+  path logs, because the suite runs with `DEBUG=true` and `utils.debug_log`
+  calls `r.log` when present. For `r.return`, use the factory-helper pattern
+  from `awscredentials_test.js` (`makeExpect200Request()`,
+  `makeRecordingRequest(state)`). Fake the Plus keyval store by pre-seeding
+  `r.variables = { cache_instance_credentials_enabled: 1, instance_credential_json: null }`.
+- **`process.env` is real and mutable** in the njs CLI: mutate it directly and
+  restore in `finally`, using a `restoreEnv(name, saved)` helper that `delete`s
+  the key when the saved value was `undefined` (assigning `undefined` re-creates
+  the key and breaks `'in'` presence checks). Caveat: env vars captured into
+  module constants at **import time** cannot be changed from inside a test —
+  they must be present in the runner's env list before the module loads.
+- **Test skeleton** (no framework): `#!env njs` shebang → license header →
+  `import mod from "include/<mod>.js"` (resolved by the `-p /etc/nginx` module
+  path) → test functions named `test<Thing>` that start with
+  `printHeader('<name>')` → one `async function test()` calling each case in
+  sequence → `test();` → closing
+  `console.log('Finished unit tests for <mod>.js');`. Assertions are
+  `if (mismatch) throw 'msg\nActual:   [..]\nExpected: [..]';`.
+- **Testing private functions**: add them to the module's `export default`
+  under the standing comment "These functions do not need to be exposed, but
+  they are exposed so that unit tests can run against them."
+- **Wiring a new test file**: the runner enumerates files explicitly — no
+  glob. Until the make-native migration is complete this means editing
+  `test.sh`: add `runUnitTestWithOutSessionToken "<file>"` /
+  `runUnitTestWithSessionToken "<file>"` calls, and add any new env var to all
+  four docker-run blocks (both functions × both njs-flag branches). This is a
+  transitional necessity, not an endorsement of test.sh.
+
+## Adding a configuration option (env var)
+
+A new environment variable is never just a code change. The full checklist:
+
+1. Read it in the njs module (import-time `const` unless it must be
+   re-evaluated per request).
+2. Document it in `docs/getting_started.md` (the environment-variable table).
+3. Add presence/validity checks to
+   `common/docker-entrypoint.d/00-check-for-required-env.sh`.
+4. Add it to the env list in `standalone_ubuntu_oss_install.sh`.
+5. Add a pass-through entry in `test/docker-compose.yaml`; if unit tests need
+   it, add it to the unit-test runner env blocks too.
+6. Add integration coverage — new settings without tests are historically
+   blocked in review.
+
+## Architecture rules
+
+- Shared helpers belong in `utils.js`; AWS signature-version logic lives in its
+  own `awssigN.js` file (one per version); credential handling in
+  `awscredentials.js`; S3 proxy/listing logic in `s3gateway.js`. See
+  `docs/development.md` for the signature flow.
+- The gateway deliberately exposes only GET and HEAD (plus OPTIONS for CORS) —
+  a security posture, not an oversight. Do not widen verb support casually.
+- Entry-point scripts run under `sh`, not bash: use `.`, never `source`, and
+  keep the syntax POSIX. Use spaces, not commas, to separate values in
+  env-var lists.
+- No whitespace or reformatting churn in PRs: revert changes outside the lines
+  you mean to touch, and disable markdown autoformatters.
+
+## Git and PR conventions
+
+- Conventional Commits format (`fix:`, `feat:`, `ci:`, `build:` ...), imperative
+  mood, subject ≤72 chars — changelogs are generated from these.
+- Shell scripts must pass `shellcheck --severity=warning`; new scripts under
+  `test/integration/` and `common/docker-entrypoint.d/` are linted automatically.
+- checkmake lints the GNUmakefile and does not follow backslash continuations —
+  keep `.PHONY` declarations on a single line.
+- Config/behavior changes usually need matching updates in both `oss/` and
+  `plus/`, plus documentation in `docs/getting_started.md` if user-facing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+Project instructions live in [AGENTS.md](AGENTS.md). Read and follow that file.

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -395,21 +395,33 @@ function redirectToS3(r) {
 function trailslashControl(r) {
     if (APPEND_SLASH) {
         // For the purposes of understanding whether this is a directory,
-        // consider the uri without query params or anchors
-        let path = r.variables.uri_path.split(/[?#]/)[0];
-
-        // Classify the decoded path so that percent-encoded dots (%2E) are
-        // visible to the extension check, matching the decoded $uri that the
-        // @trailslash rewrite redirects to. If decoding fails (e.g. invalid
-        // UTF-8 sequences that nginx passes through), classify the raw path
-        // rather than letting a URIError turn the 404 into a 500.
-        try {
-            path = decodeURIComponent(path);
-        } catch (e) {
-            // fall back to the raw path
+        // consider the uri without query params or anchors. The $uri_path
+        // map already strips query params from $request_uri, so this is
+        // defensive and otherwise only strips raw anchors. njs
+        // String.split(regex) is disproportionately expensive, so find and
+        // slice instead - this runs on every 404.
+        let path = r.variables.uri_path;
+        const separatorIdx = path.search(/[?#]/);
+        if (separatorIdx !== -1) {
+            path = path.slice(0, separatorIdx);
         }
 
-        if (!_hasExtension(path) && !_isDirectory(path)) {
+        // Classify the percent-decoded path so that encoded dots (%2E) are
+        // visible to the extension check, approximating the decoded $uri
+        // that the @trailslash rewrite redirects to. Decode byte-wise the
+        // way nginx builds $uri: decodeURIComponent() would throw URIError
+        // on sequences nginx accepts (e.g. invalid UTF-8 such as %C3) and
+        // then misclassify any encoded dots elsewhere in the same path.
+        // Unlike $uri, the result is deliberately not normalized
+        // (dot-segments and duplicate slashes are kept) - the decoded path
+        // is used for classification only, never for building the redirect.
+        if (path.indexOf('%') !== -1) {
+            path = path.replace(/%([0-9A-Fa-f]{2})/g, function (_match, hex) {
+                return String.fromCharCode(parseInt(hex, 16));
+            });
+        }
+
+        if (!_isDirectory(path) && !_hasExtension(path)) {
             return r.internalRedirect("@trailslash");
         }
     }

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -310,6 +310,11 @@ server {
     }
 
     location @trailslash {
+        # The CORS configuration needs to be imported in several places in order for
+        # it to be applied within different contexts. Without it, a cross-origin
+        # request that gets this 302 would fail the CORS check outright.
+        include /etc/nginx/conf.d/gateway/cors.conf;
+
         # 302 to request without slashes
         # Adding a ? to the end of the replacement param in `rewrite` prevents it from
         # appending the query string.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -135,11 +135,15 @@ transform `/some/path/` to `/some/path/index.html` when retrieving from S3.
 Default of "index.html" can be edited in `s3gateway.js`. 
 It will also redirect `/some/path` to `/some/path/` when S3 returns 404 on 
 `/some/path` if `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is set. `path` has to 
-look like a possible directory, it must not start with a `.` and not have an 
-extension. Only the final path segment is checked for an extension, so a dot 
-in an intermediate directory (e.g. `/dir.name/file`) does not prevent the 
-redirect. A final segment that begins or ends with a dot (e.g. `/.hidden`, 
-`/reports.`) is treated as having an extension and is not redirected.  
+look like a possible directory: it must not end with a slash, and its final 
+path segment must not contain a dot. Only the final segment is checked, so a 
+dot in an intermediate directory (e.g. `/dir.name/file`) does not prevent 
+the redirect, while any dot in the final segment (e.g. `/file.jpg`, 
+`/releases/v1.2.3`, `/.hidden`, `/reports.`) is treated as a file extension 
+and is not redirected. The path is percent-decoded before this check, so an 
+encoded dot (`%2E`) counts as a dot and an encoded slash (`%2F`) counts as a 
+directory separator (e.g. `/foo%2F` is treated as a directory and is not 
+redirected).  
 
 ### Hosting a Bucket as a Subfolder on an ALB
 

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -287,8 +287,17 @@ function testHasExtension() {
 function testTrailslashControl() {
     printHeader('testTrailslashControl');
 
-    // Requires APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true in the test
-    // environment so that the redirect branch is reachable.
+    // trailslashControl reads APPEND_SLASH_FOR_POSSIBLE_DIRECTORY into a
+    // module-level const at import time, so the flag must be present in the
+    // unit test runner environment (test.sh sets it in all four docker-run
+    // blocks). Fail fast with a setup error rather than a misleading
+    // assertion failure when it is missing.
+    if (process.env['APPEND_SLASH_FOR_POSSIBLE_DIRECTORY'] !== 'true') {
+        throw 'testTrailslashControl requires ' +
+            'APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true in the unit test ' +
+            'runner environment (see test.sh)';
+    }
+
     const testCases = [
         // Extension-less paths that look like possible directories get the
         // append-slash redirect, even under a dotted directory (issue #522)
@@ -299,9 +308,16 @@ function testTrailslashControl() {
         // Percent-encoded dots are decoded before classification, so this
         // is a file, not a possible directory
         ['/dir/file%2Ejpg', '@error404'],
-        // Undecodable sequences must not throw; the raw path is classified
+        // Sequences that are invalid UTF-8 must not throw; they are decoded
+        // byte-wise the same way nginx builds $uri
         ['/foo%C3', '@trailslash'],
+        // ... including when they appear alongside an encoded dot, which
+        // must still be visible to the extension check
+        ['/dir/file%2Ejpg%C3', '@error404'],
         ['/file.jpg', '@error404'],
+        // An encoded trailing slash decodes to a directory (matching the
+        // decoded $uri), so it is not redirected
+        ['/foo%2F', '@error404'],
         // Directories fall through to the 404 handler
         ['/dir/', '@error404']
     ];


### PR DESCRIPTION
### Proposed changes

Follow-ups to #546 (`trailslashControl` classifying the percent-decoded path), found by review:

- **Byte-wise `%XX` decode instead of `decodeURIComponent` + try/catch.** One invalid sequence anywhere in the path (e.g. `%C3`, which nginx passes through) made the decode throw, so encoded dots elsewhere in the same path (`/dir/file%2Ejpg%C3`) stayed hidden from the extension check and the spurious 302 that #546 targeted came back. The new decode mirrors how nginx unescapes `$uri` and never throws; the old fallback branch was otherwise dead in production because unguarded decodes upstream (`_escapeURIPath`) throw first. The decoded path is used for classification only, never for building the redirect.
- **404 hot-path cost.** njs `String.split(regex)` is disproportionately expensive (measured up to ~9.2 ms per call at the 8k URI cap); replaced with `search()` + `slice()`, gated the decode behind an `indexOf('%')` check, and reordered so the O(1) directory check runs before the extension regex.
- **CORS on `@trailslash`.** It was the only terminal location without the `cors.conf` include, so cross-origin requests that newly route there got a CORS-less 302 (hard failure at the redirect hop) instead of a CORS-carrying 404. No-op when CORS is disabled.
- **Docs.** `getting_started.md` still claimed the whole path 'must not start with a `.`' two lines above the new final-segment rule; rewrote the paragraph to document final-segment classification, percent-decoding, and the `%2E`/`%2F` semantics.
- **Unit tests.** `testTrailslashControl` now fails fast with a clear message when `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is missing from the runner env (previously it surfaced as a misleading gateway-logic assertion), and new rows lock in the `%2F` and mixed-encoding (`%2Ejpg%C3`) cases.

Also included (separate commit): `AGENTS.md` with project rules for coding agents (njs language subset, JSDoc conventions, unit-test mocking rules, env-var checklist) and a `CLAUDE.md` pointer to it.

Verified: unit suite passes in both session-token modes; the trailslash changes were additionally exercised against a 22-case adversarial matrix (`%2E`/`%2F`/`%C3` mixes, anchors, dotfiles, 8k paths) in the project's njs image.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).