### PR TITLE
fix: reject non-read methods proxied by the index.html location

### DIFF
--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -109,7 +109,7 @@ server {
     }
 
     location / {
-        # This value is templated in based on the value of $CORS_ENABLED. When
+        # This value is templated in based on the CORS_ENABLED setting. When
         # CORS is enabled, acceptable methods are GET, HEAD, and OPTIONS.
         # Otherwise, they are GET and HEAD.
         limit_except ${LIMIT_METHODS_TO} {}
@@ -277,10 +277,10 @@ server {
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 
-    location ~ /index.html$ {
+    location ~ /index\.html$ {
         # Configuration for handling locations ending with /index.html
 
-        # This value is templated in based on the value of $CORS_ENABLED. When
+        # This value is templated in based on the CORS_ENABLED setting. When
         # CORS is enabled, acceptable methods are GET, HEAD, and OPTIONS.
         # Otherwise, they are GET and HEAD.
         # Unlike `location /`, an empty limit_except block is not enough here:
@@ -292,6 +292,11 @@ server {
         limit_except ${LIMIT_METHODS_TO} {
             deny all;
         }
+
+        # Pin the default explicitly: a `satisfy any` inherited from user
+        # customizations (e.g. via s3_server.conf) would let the successful
+        # auth_request below clear the deny's 403 and reopen GH-551.
+        satisfy all;
 
         # Necessary for determining the correct URI to construct.
         set $forIndexPage true;
@@ -355,6 +360,18 @@ server {
         include /etc/nginx/conf.d/gateway/cors.conf;
 
         return 404;
+    }
+
+    location @error500 {
+        # The CORS configuration needs to be imported in several places in order for
+        # it to be applied within different contexts.
+        include /etc/nginx/conf.d/gateway/cors.conf;
+
+        # Target of the internal redirect issued by s3gateway.js loadContent
+        # when the index-page probe returns an unexpected status. Without
+        # this location that redirect fails with "could not find named
+        # location" and surfaces an unhandled 500.
+        return 500;
     }
 
     location @trailslashControl {

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -280,6 +280,19 @@ server {
     location ~ /index.html$ {
         # Configuration for handling locations ending with /index.html
 
+        # This value is templated in based on the value of $CORS_ENABLED. When
+        # CORS is enabled, acceptable methods are GET, HEAD, and OPTIONS.
+        # Otherwise, they are GET and HEAD.
+        # Unlike `location /`, an empty limit_except block is not enough here:
+        # nginx explicitly inherits the proxy_pass content handler into
+        # limit_except contexts, so unlisted methods would still be proxied to
+        # S3 with a valid signature (GH-551). deny all rejects them in the
+        # access phase before anything is sent upstream; the resulting 403 is
+        # sanitized to 404 by the error_page directive below.
+        limit_except ${LIMIT_METHODS_TO} {
+            deny all;
+        }
+
         # Necessary for determining the correct URI to construct.
         set $forIndexPage true;
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -537,5 +537,12 @@ proxy_intercept_errors on;
 error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 ```
 
+Note that not every `404` originates from S3. The gateway is read-only and
+rejects non-read request methods (anything other than `GET`/`HEAD`, plus
+`OPTIONS` when CORS is enabled) without contacting S3. On most paths the
+rejection is a `405` with an `Allow` header; on `*/index.html` paths it is
+denied in the access phase and deliberately collapsed to the same sanitized
+`404` by the `error_page` configuration shown above.
+
 ### Error `403 Access Denied` for AWS Accounts with MFA Enabled
 The REST authentication method used in this container does not work with AWS IAM roles that have MFA enabled for authentication. Please use AWS IAM role credentials that do not have MFA enabled. 

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -88,6 +88,16 @@ case "${PROXY_CACHE_BYPASS_NO_CACHE:-false}" in
   *) PROXY_CACHE_BYPASS_NO_CACHE=0 ;;
 esac
 
+# Normalize to 1/0: cors.conf.template matches "$request_method_1" literally
+# and the LIMIT_METHODS_TO selection below compares against '1', so the
+# documented true/false form would otherwise silently disable CORS. This
+# mirrors the parseBoolean normalization in
+# common/docker-entrypoint.d/01-set-defaults.envsh.
+case "${CORS_ENABLED:-false}" in
+  TRUE | true | True | YES | Yes | 1) CORS_ENABLED=1 ;;
+  *) CORS_ENABLED=0 ;;
+esac
+
 echo "S3 Backend Environment"
 echo "Access Key ID: ${AWS_ACCESS_KEY_ID}"
 echo "Origin: ${S3_SERVER_PROTO}://${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
@@ -192,8 +202,9 @@ PROXY_CACHE_VALID_FORBIDDEN=${PROXY_CACHE_VALID_FORBIDDEN:-'30s'}
 PROXY_CACHE_USE_STALE=${PROXY_CACHE_USE_STALE:-'error timeout http_500 http_502 http_503 http_504'}
 # Bypass the local cache when a client sends Cache-Control: no-cache (1=enabled, 0=disabled)
 PROXY_CACHE_BYPASS_NO_CACHE=${PROXY_CACHE_BYPASS_NO_CACHE}
-# Enables or disables CORS for the S3 Gateway (true=enabled, false=disabled)
-CORS_ENABLED=${CORS_ENABLED:-'false'}
+# Enables or disables CORS for the S3 Gateway (1=enabled, 0=disabled;
+# normalized from the documented true/false form above)
+CORS_ENABLED=${CORS_ENABLED}
 # Configure portion of URL to be removed (optional)
 STRIP_LEADING_DIRECTORY_PATH=${STRIP_LEADING_DIRECTORY_PATH:-''}
 # Configure portion of URL to be added to the beginning of the requested path (optional)

--- a/test/data/bucket-1/gh551-writeguard/index.html
+++ b/test/data/bucket-1/gh551-writeguard/index.html
@@ -1,0 +1,1 @@
+GH-551 write-guard fixture

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -169,6 +169,17 @@ assertHttpRequestEquals() {
         e "curl command: ${curl_cmd} -X "GET" -r "${range_start}"-"${range_end}" "${uri}" ${extra_arg} | ${checksum_cmd}"
         exit ${test_fail_exit_code}
     fi
+  elif [ "${method}" = "PUT" ] || [ "${method}" = "POST" ] || [ "${method}" = "DELETE" ]; then
+    # Write methods must be rejected by the gateway, so only the immediate
+    # response code is asserted - deliberately no redirect following.
+    expected_response_code="$3"
+    actual_response_code="$(${curl_cmd} -X "${method}" -o /dev/null -w '%{http_code}' "${uri}")"
+
+    if [ "${expected_response_code}" != "${actual_response_code}" ]; then
+      e "Response code didn't match expectation. Request [${method} ${uri}] Expected [${expected_response_code}] Actual [${actual_response_code}]"
+      e "curl command: ${curl_cmd} -X '${method}' -o /dev/null -w '%{http_code}' '${uri}'"
+      exit ${test_fail_exit_code}
+    fi
   else
     e "Method unsupported: [${method}]"
   fi
@@ -332,6 +343,16 @@ if [ ${is_windows} == "0" ]; then
   assertHttpRequestEquals "GET" 'a/%25%40%21%2A%28%29%3D%24%23%5E%26%7C.txt' 'data/bucket-1/a/%@!*()=$#^&|.txt'
   assertHttpRequestEquals "GET" 'a/%E3%81%93%E3%82%8C%E3%81%AF%E3%80%80This%20is%20ASCII%20%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B%20%20%D7%97%D7%9F%20.txt' "data/bucket-1/a/これは　This is ASCII системы  חן .txt"
 fi
+
+# GH-551 regression: the regex location for */index.html paths must reject
+# non-read methods at the nginx layer and never proxy them to S3. The
+# limit_except denial (403) is sanitized to 404 by the location's error_page.
+assertHttpRequestEquals "DELETE" "/statichost/index.html" "404"
+assertHttpRequestEquals "PUT" "/statichost/index.html" "404"
+assertHttpRequestEquals "POST" "/statichost/index.html" "404"
+# The object must still exist afterward: the rejected DELETE above must not
+# have reached the bucket.
+assertHttpRequestEquals "GET" "/statichost/index.html" "data/bucket-1/statichost/index.html"
 
 if [ "${index_page}" == "1" ]; then
 assertHttpRequestEquals "GET" "/statichost/" "data/bucket-1/statichost/index.html"

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -38,7 +38,7 @@ checksum_length=32
 ## remove this once UTF-8 issue solved.
 
 is_windows="0"
-if [ -z "${OS}" ] && [ "${OS}" == "Windows_NT" ]; then
+if [ -n "${OS:-}" ] && [ "${OS}" == "Windows_NT" ]; then
   is_windows="1"
 elif command -v uname > /dev/null; then
   uname_output="$(uname -s)"
@@ -181,7 +181,10 @@ assertHttpRequestEquals() {
       exit ${test_fail_exit_code}
     fi
   else
+    # A typo'd method must fail the suite loudly - silently continuing here
+    # would make every assertion with a bad method vacuously pass.
     e "Method unsupported: [${method}]"
+    exit ${test_fail_exit_code}
   fi
 }
 
@@ -347,12 +350,27 @@ fi
 # GH-551 regression: the regex location for */index.html paths must reject
 # non-read methods at the nginx layer and never proxy them to S3. The
 # limit_except denial (403) is sanitized to 404 by the location's error_page.
-assertHttpRequestEquals "DELETE" "/statichost/index.html" "404"
-assertHttpRequestEquals "PUT" "/statichost/index.html" "404"
-assertHttpRequestEquals "POST" "/statichost/index.html" "404"
-# The object must still exist afterward: the rejected DELETE above must not
-# have reached the bucket.
-assertHttpRequestEquals "GET" "/statichost/index.html" "data/bucket-1/statichost/index.html"
+# A dedicated fixture is used so that (a) a regression's DELETE/PUT cannot
+# corrupt /statichost/index.html, which the static-hosting assertions below
+# depend on and which is never re-seeded between configurations, and (b) the
+# verifying GET cannot be satisfied from a proxy_cache entry warmed by any
+# other assertion (proxy_cache_key is "$request_method$host$uri").
+# Note that only DELETE and PUT give the GET real teeth: a pre-fix gateway
+# also surfaced POST as a sanitized 404 (upstream error via error_page), so
+# the POST assertion pins the sanitized status, not the non-forwarding.
+assertHttpRequestEquals "DELETE" "/gh551-writeguard/index.html" "404"
+assertHttpRequestEquals "PUT" "/gh551-writeguard/index.html" "404"
+assertHttpRequestEquals "POST" "/gh551-writeguard/index.html" "404"
+# The object must still exist afterward with its original content: the
+# rejected DELETE/PUT above must not have reached the bucket.
+assertHttpRequestEquals "GET" "/gh551-writeguard/index.html" "data/bucket-1/gh551-writeguard/index.html"
+
+# The write-method policy for ordinary object paths lives in `location /`:
+# its empty limit_except starves unlisted methods of a content handler, so
+# nginx's static module rejects them and the server-level error_page answers
+# 405 with an Allow header - nothing is ever sent to S3.
+assertHttpRequestEquals "PUT" "a.txt" "405"
+assertHttpRequestEquals "DELETE" "a.txt" "405"
 
 if [ "${index_page}" == "1" ]; then
 assertHttpRequestEquals "GET" "/statichost/" "data/bucket-1/statichost/index.html"


### PR DESCRIPTION
### Proposed changes

Closes #551.

`location ~ /index.html$` had no method restriction, and nginx regex locations beat the `location /` prefix match — so any external client could send e.g. `DELETE /some/dir/index.html` (or a `PUT` with a body) directly to this location, and the request was proxied to S3 **signed with the gateway's credentials for that method**. Under a permissive IAM role this allowed unauthenticated deletion/overwrite of any key ending in `/index.html`, with the response masked to 404 either way.

**The fix** adds `limit_except ${LIMIT_METHODS_TO} { deny all; }` to the location. One deviation from the sketch in #551: an empty `limit_except {}` block (as used in `location /`) is **not** sufficient here — nginx's proxy module explicitly re-installs the `proxy_pass` content handler inside `limit_except` contexts (`ngx_http_proxy_merge_loc_conf`), so unlisted methods would still be proxied with a valid signature. `deny all` rejects them in the access phase before anything egresses to S3; the 403 is sanitized to 404 by the location's existing `error_page` line, matching its posture of hiding S3 details. (It only works without `deny all` in `location /` because njs has no such handler inheritance — unlisted methods there fall through to the static module's 405.) CORS preflight is unaffected: with CORS enabled, OPTIONS is in the allowed mask and `cors.conf`'s rewrite-phase `return 204` still runs.

Hardening from review, in the second commit:

- `satisfy all;` pinned in the location so a user-supplied `satisfy any` (via the `s3_server.conf` extension point) can't let the always-succeeding `auth_request` clear the deny and reopen the hole.
- Regex dot escaped (`/index\.html$` no longer matches paths like `/a/indexZhtml`).
- Added the missing `@error500` named location targeted by `loadContent`'s internal redirect (previously an unhandled 500 + 'could not find named location' error log).
- `CORS_ENABLED` normalized to 1/0 in `standalone_ubuntu_oss_install.sh` — the documented `true`/`false` form silently disabled CORS on standalone installs.
- Comments reworded so envsubst can't substitute `$CORS_ENABLED` in the rendered config; method-rejection behavior documented in the 404 troubleshooting section.

**Tests** (`test/integration/test_api.sh`, run in every configuration): `DELETE`/`PUT`/`POST` on a dedicated `/gh551-writeguard/index.html` fixture must return 404 and a follow-up checksum `GET` proves the object survived (the dedicated fixture keeps a regression from corrupting the shared `/statichost` fixture and keeps the verifying GET out of warm proxy-cache entries); `PUT`/`DELETE a.txt` → 405 pins the `location /` contract. These are strong pre-fix failures: with the suite's MinIO credentials, a pre-fix DELETE returned 204 and actually deleted the object. Also: the assert helper now fails loudly on unsupported methods, and the unsatisfiable Windows `${OS}` check is fixed.

Verified with `make lint` and a full `make test` (image rebuild + unit suite in both session-token modes + all integration configurations) — green.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).