### PR TITLE
fix: allow CORS_ALLOW_PRIVATE_NETWORK_ACCESS to be set

### DIFF
--- a/common/docker-entrypoint.d/01-set-defaults.envsh
+++ b/common/docker-entrypoint.d/01-set-defaults.envsh
@@ -70,7 +70,7 @@ fi
 
 # See documentation for this feature. We do not parse this as a boolean
 # since "true" and "false" are the required values of the header this populates
-if [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS+x}" != "true" ] && [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS+x}" != "false" ]; then
+if [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS:-}" != "true" ] && [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS:-}" != "false" ]; then
   export CORS_ALLOW_PRIVATE_NETWORK_ACCESS=""
 fi
 


### PR DESCRIPTION
## What

Fixes the validity check for `CORS_ALLOW_PRIVATE_NETWORK_ACCESS` in `common/docker-entrypoint.d/01-set-defaults.envsh` so the variable can actually be set to `true`/`false`.

## Why

The check ported into this script by #449 compared `"${CORS_ALLOW_PRIVATE_NETWORK_ACCESS+x}"` against `"true"`/`"false"`, but the `+x` parameter expansion only ever yields `"x"` or `""` — so the guard always fired and blanked the variable. As a result the `Access-Control-Allow-Private-Network` header could never be enabled in any image built since October 2025, matching the empty `CORS Allow Private Network Access:` startup log line reported in #475.

The fix compares the actual value via the `:-` expansion, which restores the pre-#449 behavior (and matches the equivalent check in `standalone_ubuntu_oss_install.sh`) while remaining safe under `set -u` when the variable is unset.

## Verification

Sourced the script under `sh` across the input matrix:

| input | result |
|---|---|
| unset | `""` (header suppressed) |
| `""` | `""` (header suppressed) |
| `true` | `true` |
| `false` | `false` |
| `garbage` | `""` (header suppressed) |

`make lint` (checkmake + shellcheck) passes.

Fixes #475