### PR TITLE
fix: report per-S3_STYLE origin in startup settings banner

### DIFF
--- a/common/docker-entrypoint.d/99-output-settings.sh
+++ b/common/docker-entrypoint.d/99-output-settings.sh
@@ -24,11 +24,16 @@ else
   ipv6_listen="disabled"
 fi
 
+# S3_UPSTREAM and S3_HOST_HEADER are computed per S3_STYLE by
+# 01-set-defaults.envsh (sourced by the entrypoint before this script runs),
+# so report those rather than assuming the virtual-host form - path style
+# keeps the bucket out of the hostname entirely (GH-367).
 cat <<EOM
 S3 Backend Environment:
   Service: ${S3_SERVICE:-s3}
   Access Key ID: ${AWS_ACCESS_KEY_ID}
-  Origin: ${S3_SERVER_PROTO}://${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}
+  Origin: ${S3_SERVER_PROTO}://${S3_UPSTREAM}
+  Host Header: ${S3_HOST_HEADER}
   Region: ${S3_REGION}
   Addressing Style: ${S3_STYLE}
   AWS Signatures Version: v${AWS_SIGS_VERSION}

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -98,9 +98,30 @@ case "${CORS_ENABLED:-false}" in
   *) CORS_ENABLED=0 ;;
 esac
 
+# This is the primary logic to determine the s3 host used for the
+# upstream (the actual proxying action) as well as the `Host` header
+#
+# It is currently slightly more complex than necessary because we are transitioning
+# to a new logic which is defined by "virtual-v2". "virtual-v2" is the recommended setting
+# for all deployments.
+
+# S3_UPSTREAM needs the port specified. The port must
+# correspond to https/http in the proxy_pass directive.
+if [ "${S3_STYLE}" == "virtual-v2" ]; then
+  S3_UPSTREAM="${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
+  S3_HOST_HEADER="${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
+elif [ "${S3_STYLE}" == "path" ]; then
+  S3_UPSTREAM="${S3_SERVER}:${S3_SERVER_PORT}"
+  S3_HOST_HEADER="${S3_SERVER}:${S3_SERVER_PORT}"
+else
+  S3_UPSTREAM="${S3_SERVER}:${S3_SERVER_PORT}"
+  S3_HOST_HEADER="${S3_BUCKET_NAME}.${S3_SERVER}"
+fi
+
 echo "S3 Backend Environment"
 echo "Access Key ID: ${AWS_ACCESS_KEY_ID}"
-echo "Origin: ${S3_SERVER_PROTO}://${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
+echo "Origin: ${S3_SERVER_PROTO}://${S3_UPSTREAM}"
+echo "Host Header: ${S3_HOST_HEADER}"
 echo "Region: ${S3_REGION}"
 echo "Addressing Style: ${S3_STYLE}"
 echo "AWS Signatures Version: v${AWS_SIGS_VERSION}"
@@ -227,31 +248,12 @@ LIMIT_METHODS_TO_CSV="GET, HEAD"
 EOF
 fi
 
-# This is the primary logic to determine the s3 host used for the
-# upstream (the actual proxying action) as well as the `Host` header
-#
-# It is currently slightly more complex than necessary because we are transitioning
-# to a new logic which is defined by "virtual-v2". "virtual-v2" is the recommended setting
-# for all deployments.
-
-# S3_UPSTREAM needs the port specified. The port must
-# correspond to https/http in the proxy_pass directive.
-if [ "${S3_STYLE}" == "virtual-v2" ]; then
-  cat >> "/etc/nginx/environment" << EOF
-S3_UPSTREAM="${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
-S3_HOST_HEADER="${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}"
+# S3_UPSTREAM and S3_HOST_HEADER are computed from S3_STYLE before the
+# settings banner above so the logged origin matches the effective values.
+cat >> "/etc/nginx/environment" << EOF
+S3_UPSTREAM="${S3_UPSTREAM}"
+S3_HOST_HEADER="${S3_HOST_HEADER}"
 EOF
-elif [ "${S3_STYLE}" == "path" ]; then
-  cat >> "/etc/nginx/environment" << EOF
-S3_UPSTREAM="${S3_SERVER}:${S3_SERVER_PORT}"
-S3_HOST_HEADER="${S3_SERVER}:${S3_SERVER_PORT}"
-EOF
-else
-  cat >> "/etc/nginx/environment" << EOF
-S3_UPSTREAM="${S3_SERVER}:${S3_SERVER_PORT}"
-S3_HOST_HEADER="${S3_BUCKET_NAME}.${S3_SERVER}"
-EOF
-fi
 
 set -o nounset   # abort on unbound variable
 

--- a/test.sh
+++ b/test.sh
@@ -534,6 +534,9 @@ runUnitTestWithSessionToken "s3gateway_test.js"
 p "Testing IPv6 entrypoint script"
 bash "${test_dir}/integration/test_entrypoint_ipv6.sh" "${docker_cmd}" "${gateway_listen_port}"
 
+p "Testing settings output entrypoint script"
+bash "${test_dir}/integration/test_entrypoint_output_settings.sh" "${docker_cmd}"
+
 ### INTEGRATION TESTS
 # The arguments correspond to flags given to the integration test runner
 # integration_test 2 0 0 0

--- a/test/integration/test_entrypoint_output_settings.sh
+++ b/test/integration/test_entrypoint_output_settings.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright 2026 F5, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Tests for the 99-output-settings.sh entrypoint banner (GH-367). The Origin
+# and Host Header lines must reflect the S3_UPSTREAM/S3_HOST_HEADER values
+# computed per S3_STYLE by 01-set-defaults.envsh instead of always assuming
+# the virtual-host form, which showed a bucket-prefixed hostname even for
+# path-style deployments. Sourcing 01-set-defaults.envsh before running the
+# banner script mirrors the entrypoint's numeric-order execution.
+
+set -o errexit   # abort on nonzero exit status
+set -o pipefail  # don't hide errors within pipes
+
+docker_cmd=$1
+
+check_banner() {
+  style=$1
+  expected_origin=$2
+  expected_host_header=$3
+
+  # MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
+  # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
+  output=$(MSYS_NO_PATHCONV=1 "${docker_cmd}" run --rm \
+    -e S3_BUCKET_NAME=test-bucket \
+    -e S3_SERVER=s3.example.com \
+    -e S3_SERVER_PORT=9000 \
+    -e S3_SERVER_PROTO=http \
+    -e CORS_ENABLED=false \
+    -e S3_STYLE="${style}" \
+    --entrypoint /bin/sh nginx-s3-gateway -c \
+    '. /docker-entrypoint.d/01-set-defaults.envsh && sh /docker-entrypoint.d/99-output-settings.sh')
+
+  if ! echo "${output}" | grep -qF "Origin: ${expected_origin}"; then
+    >&2 echo "FAIL [S3_STYLE=${style}]: expected 'Origin: ${expected_origin}' in banner:"
+    >&2 echo "${output}"
+    exit 2
+  fi
+
+  if ! echo "${output}" | grep -qF "Host Header: ${expected_host_header}"; then
+    >&2 echo "FAIL [S3_STYLE=${style}]: expected 'Host Header: ${expected_host_header}' in banner:"
+    >&2 echo "${output}"
+    exit 2
+  fi
+}
+
+# Path style keeps the bucket out of the hostname entirely - the GH-367 fix.
+check_banner path       "http://s3.example.com:9000"             "s3.example.com:9000"
+check_banner virtual-v2 "http://test-bucket.s3.example.com:9000" "test-bucket.s3.example.com:9000"
+# Legacy virtual style connects to the bare server and routes the bucket
+# through the Host header (which carries no port).
+check_banner virtual    "http://s3.example.com:9000"             "test-bucket.s3.example.com"
+
+echo "PASS: settings banner reports per-S3_STYLE origin and host header"


### PR DESCRIPTION
Fixes #367

## What

The startup settings banner always printed the virtual-host form for its `Origin:` line:

```
Origin: ${S3_SERVER_PROTO}://${S3_BUCKET_NAME}.${S3_SERVER}:${S3_SERVER_PORT}
```

With `S3_STYLE=path` (e.g. MinIO), the bucket lives in the URI path, not the hostname, so the logged origin (`http://mybucket.service.namespace.svc:9000`) looks like a misconfiguration even though the gateway routes correctly.

## How

`01-set-defaults.envsh` already computes and exports `S3_UPSTREAM` and `S3_HOST_HEADER` per `S3_STYLE` before `99-output-settings.sh` runs, so the banner now reports those directly instead of duplicating the style logic:

| S3_STYLE   | Origin                              | Host Header                     |
|------------|-------------------------------------|---------------------------------|
| path       | `http://s3.example.com:9000`        | `s3.example.com:9000`           |
| virtual-v2 | `http://bucket.s3.example.com:9000` | `bucket.s3.example.com:9000`    |
| virtual    | `http://s3.example.com:9000`        | `bucket.s3.example.com`         |

The new `Host Header:` line makes the legacy `virtual` style legible: nginx connects to the bare server and routes the bucket through the Host header.

`standalone_ubuntu_oss_install.sh` gets the same treatment — the `S3_STYLE` branching moves above the banner as plain shell assignments, and the content written to `/etc/nginx/environment` is byte-identical to before.

## Testing

- New `test/integration/test_entrypoint_output_settings.sh` runs `01-set-defaults.envsh` + `99-output-settings.sh` inside the built image for all three styles and asserts the `Origin:` / `Host Header:` lines; wired into the runner beside the IPv6 entrypoint test.
- `make lint` and the full `make test` suite pass locally.
- Manual check of the issue's repro (`S3_STYLE=path`, in-cluster MinIO hostname) now prints `Origin: http://service.namespace.svc.cluster.local:9000` with no bucket prefix.