### PR TITLE
fix: use live clock for credential expiry check

### DIFF
--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -34,6 +34,11 @@ const fs = require('fs');
 /**
  * The current moment as a timestamp. This timestamp will be used across
  * functions in order for there to be no variations in signatures.
+ *
+ * This constant exists solely for signature-timestamp stability and is stable
+ * per njs VM context, not per wall-clock moment. Never use it for freshness
+ * or expiry decisions: if module scope persists across requests (e.g. the
+ * QuickJS engine with context reuse), it freezes at context-creation time.
  * @type {Date}
  */
 const NOW = new Date();
@@ -273,7 +278,10 @@ async function fetchCredentials(r) {
         // In some situations (including EC2 and Fargate) current.expiration will be an RFC 3339 string - see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
         const expireAt = typeof current.expiration == 'number' ? current.expiration * 1000 : current.expiration
         const exp = new Date(expireAt).getTime() - maxValidityOffsetMs;
-        if (NOW.getTime() < exp) {
+        /* Use a live clock rather than NOW: NOW is stable per njs VM context
+           for signature consistency, so it goes stale for expiry checks
+           whenever module scope outlives a single request. */
+        if (new Date().getTime() < exp) {
             r.return(200);
             return;
         }

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -566,10 +566,14 @@ async function _fetchWebIdentityCredentials(r) {
 }
 
 /**
- * Get the current timestamp. This timestamp will be used across functions in
- * order for there to be no variations in signatures.
+ * Get the timestamp used across functions in order for there to be no
+ * variations in signatures.
  *
- * @returns {Date} The current moment as a timestamp
+ * The returned value is the module-level NOW constant, which is stable per
+ * njs VM context rather than the current wall-clock moment. Never use it for
+ * freshness or expiry decisions - see the note on NOW.
+ *
+ * @returns {Date} signature-stable timestamp for the current VM context
  */
 function Now() {
     return NOW;

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -244,6 +244,80 @@ function testReadAndWriteCredentialsFromKeyValStore() {
     }
 }
 
+async function testFetchCredentialsRefreshesExpiredCache() {
+    printHeader('testFetchCredentialsRefreshesExpiredCache');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-expired-cache', '.json');
+    var recordedUrl = null;
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
+    /* Seed the cache with credentials whose expiration is in the past so that
+       the freshness short-circuit must not fire. Guards against the expiry
+       check comparing to a stale timestamp instead of a live clock. */
+    fs.writeFileSync(tempFile, JSON.stringify({
+        accessKeyId: 'AN_EXPIRED_ACCESS_KEY_ID',
+        secretAccessKey: 'AN_EXPIRED_SECRET_ACCESS_KEY',
+        sessionToken: 'AN_EXPIRED_SECURITY_TOKEN',
+        expiration: '2017-05-17T15:09:54Z',
+    }));
+    globalThis.ngx.fetch = function (url) {
+        console.log(' fetching mock credentials to replace the expired cache');
+        recordedUrl = url;
+
+        return Promise.resolve({
+            ok: true,
+            json: function () {
+                return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
+            }
+        });
+    };
+    var r = makeExpect200Request();
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+
+        if (recordedUrl !== 'http://169.254.170.2/example') {
+            throw 'Expired cached credentials were not refreshed. ' +
+                `Recorded refresh URL: ${recordedUrl}`;
+        }
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+        removeIfExists(tempFile);
+    }
+}
+
+async function testFetchCredentialsUsesFreshCache() {
+    printHeader('testFetchCredentialsUsesFreshCache');
+    clearProviderEnv();
+    var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
+    var tempFile = tempFilePath('credentials-unit-test-fresh-cache', '.json');
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
+    /* Expiration far enough in the future to stay comfortably beyond the
+       4.5-minute early-refresh offset applied to the expiration. */
+    fs.writeFileSync(tempFile, JSON.stringify({
+        accessKeyId: 'A_FRESH_ACCESS_KEY_ID',
+        secretAccessKey: 'A_FRESH_SECRET_ACCESS_KEY',
+        sessionToken: 'A_FRESH_SECURITY_TOKEN',
+        expiration: '2100-01-01T00:00:00Z',
+    }));
+    globalThis.ngx.fetch = function (url) {
+        throw 'Fresh cached credentials must not be refreshed. ' +
+            `Attempted fetch URL: ${url}`;
+    };
+    var r = makeExpect200Request();
+
+    try {
+        process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
+        await awscred.fetchCredentials(r);
+    } finally {
+        restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+        removeIfExists(tempFile);
+    }
+}
+
 async function testEcsCredentialRetrieval() {
     printHeader('testEcsCredentialRetrieval');
     clearProviderEnv();
@@ -809,6 +883,8 @@ function testWriteInvalidCredentials() {
 async function test() {
     await testEc2CredentialRetrieval();
     await testEcsCredentialRetrieval();
+    await testFetchCredentialsRefreshesExpiredCache();
+    await testFetchCredentialsUsesFreshCache();
     await testEKSPodIdentityCredentialRetrieval();
     await testEKSPodIdentityCredentialRetrievalNon200Response();
     await testEc2CredentialRetrievalNon200Response();

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -37,6 +37,18 @@ const IMDS_TOKEN_URL = 'http://169.254.169.254/latest/api/token';
 const IMDS_SECURITY_CREDS_URL = 'http://169.254.169.254/latest/meta-data/iam/security-credentials/';
 
 /**
+ * Relative URI assigned to AWS_CONTAINER_CREDENTIALS_RELATIVE_URI by tests
+ * exercising the ECS credential provider path.
+ */
+const ECS_CREDS_RELATIVE_URI = '/example';
+
+/**
+ * Full ECS credentials endpoint URL the module is expected to fetch: the
+ * fixed ECS credential base joined with the relative URI above.
+ */
+const ECS_CREDS_URL = `http://169.254.170.2${ECS_CREDS_RELATIVE_URI}`;
+
+/**
  * Deletes every provider-selection env var so that each test opts into
  * exactly one credential provider path.
  */
@@ -250,7 +262,7 @@ async function testFetchCredentialsRefreshesExpiredCache() {
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-expired-cache', '.json');
     var recordedUrl = null;
-    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
     /* Seed the cache with credentials whose expiration is in the past so that
        the freshness short-circuit must not fire. Guards against the expiry
        check comparing to a stale timestamp instead of a live clock. */
@@ -277,7 +289,7 @@ async function testFetchCredentialsRefreshesExpiredCache() {
         process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
         await awscred.fetchCredentials(r);
 
-        if (recordedUrl !== 'http://169.254.170.2/example') {
+        if (recordedUrl !== ECS_CREDS_URL) {
             throw 'Expired cached credentials were not refreshed. ' +
                 `Recorded refresh URL: ${recordedUrl}`;
         }
@@ -293,7 +305,7 @@ async function testFetchCredentialsUsesFreshCache() {
     clearProviderEnv();
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-fresh-cache', '.json');
-    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
     /* Expiration far enough in the future to stay comfortably beyond the
        4.5-minute early-refresh offset applied to the expiration. */
     fs.writeFileSync(tempFile, JSON.stringify({
@@ -302,15 +314,34 @@ async function testFetchCredentialsUsesFreshCache() {
         sessionToken: 'A_FRESH_SECURITY_TOKEN',
         expiration: '2100-01-01T00:00:00Z',
     }));
+    /* Record instead of throwing from the stub: a throw here would be
+       swallowed by fetchCredentials' try/catch and resurface only as an
+       unexplained 500, hiding the real cause of a regression. */
+    var recordedUrl = null;
     globalThis.ngx.fetch = function (url) {
-        throw 'Fresh cached credentials must not be refreshed. ' +
-            `Attempted fetch URL: ${url}`;
+        recordedUrl = url;
+
+        return Promise.resolve({
+            ok: true,
+            json: function () {
+                return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
+            }
+        });
     };
-    var r = makeExpect200Request();
+    var state = {};
+    var r = makeRecordingRequest(state);
 
     try {
         process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
         await awscred.fetchCredentials(r);
+
+        if (recordedUrl !== null) {
+            throw 'Fresh cached credentials must not be refreshed. ' +
+                `Attempted fetch URL: ${recordedUrl}`;
+        }
+        if (state.returnedCode !== 200) {
+            throw 'Expected 200 status code, got: ' + state.returnedCode;
+        }
     } finally {
         restoreEnv('AWS_CREDENTIALS_TEMP_FILE', originalCredentialPath);
         delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
@@ -324,7 +355,7 @@ async function testEcsCredentialRetrieval() {
     var originalCredentialPath = process.env['AWS_CREDENTIALS_TEMP_FILE'];
     var tempFile = tempFilePath('credentials-unit-test-ecs-happy', '.json');
     var recordedUrl = null;
-    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = '/example';
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
     globalThis.ngx.fetch = function (url) {
         console.log(' fetching mock credentials');
         recordedUrl = url;
@@ -342,7 +373,7 @@ async function testEcsCredentialRetrieval() {
         process.env['AWS_CREDENTIALS_TEMP_FILE'] = tempFile;
         await awscred.fetchCredentials(r);
 
-        if (recordedUrl !== 'http://169.254.170.2/example') {
+        if (recordedUrl !== ECS_CREDS_URL) {
             throw `No or wrong ECS credentials fetch URL recorded: ${recordedUrl}`;
         }
     } finally {


### PR DESCRIPTION
## What

Switches the cached-credential expiry comparison in `fetchCredentials()` from the module-scope `NOW` timestamp to a live `new Date()`, and documents on `NOW` that it exists solely for signature-timestamp stability and must never be used for freshness decisions.

## Why

`const NOW = new Date()` is only "current" because the default njs engine re-evaluates module scope per request — an implementation detail, not a guarantee. If module scope persists across requests (e.g. the QuickJS engine with `js_context_reuse`, or future njs optimizations), `NOW` freezes at context-creation time:

1. `NOW.getTime() < exp` keeps returning `true` after cached credentials have really expired, so refresh silently stops and the gateway signs with expired credentials (S3 403, sanitized to 404 by the catch-all `error_page`).
2. The signing timestamps freeze too, eventually tripping `RequestTimeTooSkewed`.

Latent today on the default engine; filed as #550 to remove the assumption before an engine/configuration change turns it into a production incident.

The signing invariant is deliberately untouched: `Now()` still returns a single stable timestamp per request so the eight-digit date and `x-amz-date` derived from it in `awssig4.js` always agree.

## Testing

Two regression tests added to `test/unit/awscredentials_test.js`, covering both branches of the expiry check:

- `testFetchCredentialsRefreshesExpiredCache` — seeds the credential cache with an expired fixture and asserts `fetchCredentials` performs a refresh fetch rather than returning 200 from the freshness short-circuit (the test suggested in #550).
- `testFetchCredentialsUsesFreshCache` — seeds a far-future expiration and asserts the short-circuit returns 200 without contacting the credentials endpoint.

`make test` (full unit + integration suite, OSS image) passes.

Fixes #550