### PR TITLE
fix: don't prepend bucket name on path-style index page probes

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -299,30 +299,42 @@ function s3BaseUri(r) {
  * Returns the s3 path given the incoming request
  *
  * @param r {NginxHTTPRequest} HTTP request
+ * @param opts {Object} Additional options for assembling the s3 URI
+ * @param opts.preserveBasePath {boolean} If set, modifications to the base path such as the addition of the bucket name will not be performed.
  * @returns {string} uri for s3 request
  */
-function s3uri(r) {
-    let uriPath = r.variables.uri_path;
-    const basePath = s3BaseUri(r);
+function s3uri(r, opts) {
+    if (!opts) {
+        opts = { preserveBasePath: false };
+    }
+
+    let basePath;
     let path;
+    let uriPath = r.variables.uri_path;
+
+    if (opts.preserveBasePath) {
+        basePath = '';
+    } else {
+        basePath = s3BaseUri(r);
+    }
 
     // Create query parameters only if directory listing is enabled.
     if (ALLOW_LISTING && !utils.parseBoolean(r.variables.forIndexPage)) {
         const queryParams = _s3DirQueryParams(uriPath, r.method);
         if (queryParams.length > 0) {
-            path = basePath + '?' + queryParams;
+            path = `${basePath}?${queryParams}`;
         } else {
-            path = _escapeURIPath(basePath + uriPath);
+            path = _escapeURIPath(`${basePath}${uriPath}`);
         }
     } else {
         // This is a path that will resolve to an index page
         if (PROVIDE_INDEX_PAGE  && _isDirectory(uriPath) ) {
             uriPath += INDEX_PAGE;
         }
-        path = _escapeURIPath(basePath + uriPath);
+        path = _escapeURIPath(`${basePath}${uriPath}`);
     }
 
-    utils.debug_log(r, 'S3 Request URI: ' + r.method + ' ' + path);
+    utils.debug_log(r, `S3 Request URI: ${r.method} ${path}`);
     return path;
 }
 
@@ -440,7 +452,12 @@ async function loadContent(r) {
         r.internalRedirect("@s3Directory");
         return;
     }
-    const uri = s3uri(r);
+    // For the index page check, don't add the bucket name
+    // in the case of a path-style uri because the subrequest will
+    // add it after the redirect.  Adding it here would result in the
+    // bucket name being added twice.
+    const uri = s3uri(r, { preserveBasePath: true });
+
     let reply = await ngx.fetch(
         `http://127.0.0.1:80${uri}`
     );

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -64,12 +64,6 @@ const APPEND_SLASH = utils.parseBoolean(process.env['APPEND_SLASH_FOR_POSSIBLE_D
  * */
 const FOUR_O_FOUR_ON_EMPTY_BUCKET = utils.parseBoolean(process.env['FOUR_O_FOUR_ON_EMPTY_BUCKET']);
 /**
- * Flag indicating why type of S3 URI to use. Valid values are 'virtual' and
- * 'path'. If not set, 'virtual' is assumed.
- * @type {string}
- * */
-const S3_STYLE = process.env['S3_STYLE'];
-/**
  * Additional header prefixes to strip from the response before sending to the
  * client. This is useful for removing headers that may contain sensitive
  * information.
@@ -283,9 +277,14 @@ function _s3ReqParamsForSigV4(r, bucket, host) {
  */
 function s3BaseUri(r) {
     const bucket = process.env['S3_BUCKET_NAME'];
+    // Valid S3_STYLE values are 'virtual', 'virtual-v2' and 'path'; anything
+    // else behaves as virtual-style. Read per call (like S3_BUCKET_NAME
+    // above) rather than into an import-time const so unit tests can
+    // exercise both addressing styles within a single run.
+    const s3Style = process.env['S3_STYLE'];
     let basePath;
 
-    if (S3_STYLE === 'path') {
+    if (s3Style === 'path') {
         utils.debug_log(r, 'Using path style uri : ' + '/' + bucket);
         basePath = '/' + bucket;
     } else {
@@ -300,7 +299,10 @@ function s3BaseUri(r) {
  *
  * @param r {NginxHTTPRequest} HTTP request
  * @param opts {Object} Additional options for assembling the s3 URI
- * @param opts.preserveBasePath {boolean} If set, modifications to the base path such as the addition of the bucket name will not be performed.
+ * @param opts.preserveBasePath {boolean} If true, do not prepend the bucket
+ *   name for path-style configurations. This produces a URI addressed to
+ *   this gateway - which prepends the bucket name itself when proxying to
+ *   S3 - rather than a URI addressed directly to S3.
  * @returns {string} uri for s3 request
  */
 function s3uri(r, opts) {
@@ -452,10 +454,12 @@ async function loadContent(r) {
         r.internalRedirect("@s3Directory");
         return;
     }
-    // For the index page check, don't add the bucket name
-    // in the case of a path-style uri because the subrequest will
-    // add it after the redirect.  Adding it here would result in the
-    // bucket name being added twice.
+    // This URI is addressed to the gateway itself, not to S3: both the
+    // loopback probe below and the internalRedirect on success re-enter
+    // this server's `location ~ /index\.html$`, which prepends the bucket
+    // name when proxying path-style requests to S3. Including the bucket
+    // name here as well would duplicate it in the upstream request (GH-210),
+    // so ask for the gateway-relative path instead.
     const uri = s3uri(r, { preserveBasePath: true });
 
     let reply = await ngx.fetch(

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -278,7 +278,7 @@ server {
         # Comment out this line to receive the error messages returned by S3
         error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
-        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3Uri;
+        proxy_pass  ${S3_SERVER_PROTO}://storage_urls$s3uri;
         include /etc/nginx/conf.d/gateway/s3listing_location.conf;
     }
 

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -343,6 +343,76 @@ function testTrailslashControl() {
     });
 }
 
+/**
+ * Restores an env var to a previously saved value. Deletes the variable when
+ * the saved value is undefined - assigning undefined would re-create the key
+ * with an undefined value, which breaks 'in'-based presence checks.
+ */
+function restoreEnv(name, value) {
+    if (value === undefined) {
+        delete process.env[name];
+    } else {
+        process.env[name] = value;
+    }
+}
+
+function testS3uri() {
+    printHeader('testS3uri');
+
+    const savedStyle = process.env['S3_STYLE'];
+    const bucket = process.env['S3_BUCKET_NAME'];
+
+    function makeRequest(uriPath) {
+        const r = {
+            "method": "GET",
+            "variables": {
+                "uri_path": uriPath,
+                "forIndexPage": "true"
+            }
+        };
+        r.log = function(msg) {
+            console.log(msg);
+        };
+        return r;
+    }
+
+    function check(style, opts, uriPath, expected) {
+        process.env['S3_STYLE'] = style;
+        const actual = s3gateway.s3uri(makeRequest(uriPath), opts);
+        if (actual !== expected) {
+            throw `Unexpected s3uri result for S3_STYLE=${style} ` +
+                `uri_path=${uriPath}` +
+                `\nActual:   [${actual}]` +
+                `\nExpected: [${expected}]`;
+        }
+    }
+
+    try {
+        // Virtual-hosted styles never carry the bucket name in the path, so
+        // preserveBasePath is a no-op for them.
+        check('virtual-v2', undefined, '/a/c/ramen.jpg', '/a/c/ramen.jpg');
+        check('virtual-v2', { preserveBasePath: true }, '/a/c/ramen.jpg',
+            '/a/c/ramen.jpg');
+
+        // Path style prepends the bucket name by default...
+        check('path', undefined, '/a/c/ramen.jpg',
+            `/${bucket}/a/c/ramen.jpg`);
+        // ...but not for gateway-relative URIs such as the loadContent()
+        // index page probe, which re-enters the gateway and would otherwise
+        // gain the bucket name a second time (GH-210).
+        check('path', { preserveBasePath: true }, '/a/c/ramen.jpg',
+            '/a/c/ramen.jpg');
+
+        // Directory URIs, shaped like the requests loadContent() probes
+        // with. The runner env leaves PROVIDE_INDEX_PAGE unset, so no index
+        // page suffix is appended here.
+        check('path', undefined, '/a/c/', `/${bucket}/a/c/`);
+        check('path', { preserveBasePath: true }, '/a/c/', '/a/c/');
+    } finally {
+        restoreEnv('S3_STYLE', savedStyle);
+    }
+}
+
 function testEscapeURIPathPreservesDoubleSlashes() {
     printHeader('testEscapeURIPathPreservesDoubleSlashes');
     var doubleSlashed = '/testbucketer2/foo3//bar3/somedir/license';
@@ -486,6 +556,7 @@ async function test() {
     testEditHeadersHeadDirectory();
     testHasExtension();
     testTrailslashControl();
+    testS3uri();
     testEscapeURIPathPreservesDoubleSlashes();
     await testEcsCredentialRetrieval();
     await testEc2CredentialRetrieval();


### PR DESCRIPTION
## Summary

Supersedes #230 — rebased onto current main and extended with test coverage. The core fix is @4141done's commit, carried over with authorship intact.

When `ALLOW_DIRECTORY_LIST` and `PROVIDE_INDEX_PAGE` are both enabled, `loadContent()` probes for an index page by fetching the URI back through the gateway itself. That loopback request re-enters this server's `location ~ /index\.html$`, which prepends the bucket name when proxying path-style requests to S3. Building an S3-style URI (bucket included) for the probe therefore duplicated the bucket segment in the upstream request (`/bucket/bucket/dir/index.html`), so the probe always 404'd and path-style deployments got a directory listing instead of their index pages.

## Changes

- **`s3uri()` gains a `preserveBasePath` option** (from #230): skips the bucket-name prepend so the index-page probe and the internal redirect that follows it stay gateway-relative. Virtual-hosted styles never carry the bucket in the path and are unaffected.
- **Unit test coverage**: `s3BaseUri()` now reads `S3_STYLE` per call (mirroring the existing per-call `S3_BUCKET_NAME` read; runtime behavior is identical since the variable is env-whitelisted and static per worker) so tests can exercise both addressing styles in one run. New `testS3uri()` covers default and `preserveBasePath` behavior under `path` and `virtual-v2` styles for object and directory URIs. Previously nothing guarded this path: no unit test called `s3uri()` and the CI matrix only runs virtual styles.
- **Comment corrections**: the `loadContent()` comment misstated the mechanism (the probe itself re-enters the index.html location; the bucket is not added "after the redirect"), and the `preserveBasePath` JSDoc now states its purpose: producing a gateway-relative URI rather than an S3-addressed one.
- **`$s3Uri` → `$s3uri`** in the `@s3Directory` listing block. Purely cosmetic — nginx resolves variable names case-insensitively (verified against a live `js_set` variable) — re-applying 4bf8d5e, which #139 unintentionally reverted.

## Testing

- `make test` (image build + full unit and integration suite against MinIO): all pass.
- All five unit suites pass in both session-token modes against the built image.
- Negative control: the new `testS3uri` cases fail (exit 1) when run against main's `s3gateway.js`, so a regression of this bug is now caught in CI.
- Rendered config verified with `nginx -t` for path style; the unprivileged image's `sed` rewrite of `http://127.0.0.1:80` in `loadContent()` is untouched.

Fixes #210
