### PR TITLE
build: replace test.sh with make-native test runners and refactor CI

### DIFF
--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -11,8 +11,6 @@ on:
   schedule:
     - cron: "0 0 * * 1"
   workflow_dispatch:
-env:
-  CI: true
 permissions: read-all
 
 # Job progression.  We make sure that the base image [oss] builds and passes tests before kicking off the other builds
@@ -29,6 +27,23 @@ permissions: read-all
 # As a last step (only if run from main) multi-architecture images are built and pushed to Docker Hub and the GitHub Container Registry
 
 jobs:
+  lint:
+    name: Lint (checkmake + shellcheck)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # shellcheck is preinstalled on the GitHub runners; checkmake is not.
+      - name: Install checkmake
+        run: |
+          go install github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Lint
+        run: make lint
+
   build-oss-for-test:
     name: Build NGINX OSS image
     runs-on: ubuntu-24.04
@@ -104,7 +119,7 @@ jobs:
           docker load --input ${{ runner.temp }}/oss.tar
 
       - name: Run tests - stable njs version
-        run: S3_STYLE=${{ matrix.path_style }} ./test.sh --type oss
+        run: make retest NGINX_TYPE=oss S3_STYLE=${{ matrix.path_style }}
 
   build-latest-njs-for-test:
     name: Build NGINX OSS image using latest njs commit
@@ -197,7 +212,7 @@ jobs:
           docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
 
       - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
+        run: make retest-latest-njs NGINX_TYPE=oss
 
   build-unprivileged-for-test:
     name: Build NGINX OSS unprivileged image
@@ -290,7 +305,7 @@ jobs:
           docker tag nginx-s3-gateway:unprivileged-oss nginx-s3-gateway
 
       - name: Run tests - unprivileged
-        run: ./test.sh --unprivileged --type oss
+        run: make retest-unprivileged NGINX_TYPE=oss
 
 # As a last step (only if run from main) multi-architecture images are built and pushed to Docker Hub and the GitHub Container Registry
   tag-and-push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,15 +26,19 @@ as Docker images.
 ## Build, test, lint
 
 The `GNUmakefile` (GNU Make 4.x) is the **only supported interface** for build
-and test workflows. The legacy `test.sh` script still exists underneath, but we
-are migrating away from it — never invoke or recommend `./test.sh` directly.
-Run `make help` for the full target list, `make check-tools` to verify
-prerequisites (docker, docker compose, curl, mc/MinIO client).
+and test workflows. The test logic lives in `test/run_unit_tests.sh` and
+`test/run_integration_tests.sh`, which make drives; the legacy `test.sh` is a
+deprecated wrapper that only forwards to the equivalent make targets — never
+invoke or recommend it. Run `make help` for the full target list,
+`make check-tools` to verify prerequisites (docker, docker compose, curl,
+mc/MinIO client).
 
 - `make build` — build the gateway image (`NGINX_TYPE=oss` default, or `plus`).
 - `make test` — build, then run the full unit + integration suite.
 - `make retest` — rerun tests against the already-built image (fast iteration,
   but see the staleness warning below).
+- `make test-unit` / `make test-integration` — run just one half of the suite
+  against the already-built image.
 - `make test-matrix` — reproduce the CI matrix locally.
 - `make lint` — checkmake + shellcheck.
 - `make docs` — generate JSDoc reference documentation.
@@ -153,8 +157,9 @@ Per the nginx docs, nginx objects are not available in the CLI: there is no
 `ngx`, no request object `r`, and no nginx variables. Everything
 nginx-provided must be hand-mocked.
 
-- **Run tests only through make** (`make test` / `make retest`). Under the
-  hood each test file currently runs via
+- **Run tests only through make** (`make test` / `make retest` /
+  `make test-unit`). Under the hood `test/run_unit_tests.sh` runs each test
+  file via
   `docker run --entrypoint /usr/bin/njs nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/<file>`
   with a fixed env list (`AWS_ACCESS_KEY_ID=unit_test`,
   `S3_BUCKET_NAME=unit_test`, `DEBUG=true`, `S3_REGION=test-1`,
@@ -193,12 +198,11 @@ nginx-provided must be hand-mocked.
 - **Testing private functions**: add them to the module's `export default`
   under the standing comment "These functions do not need to be exposed, but
   they are exposed so that unit tests can run against them."
-- **Wiring a new test file**: the runner enumerates files explicitly — no
-  glob. Until the make-native migration is complete this means editing
-  `test.sh`: add `runUnitTestWithOutSessionToken "<file>"` /
-  `runUnitTestWithSessionToken "<file>"` calls, and add any new env var to all
-  four docker-run blocks (both functions × both njs-flag branches). This is a
-  transitional necessity, not an endorsement of test.sh.
+- **Wiring a new test file**: automatic — `test/run_unit_tests.sh` globs
+  `test/unit/*_test.js`, so a new `<name>_test.js` file is discovered and run
+  in both session-token modes without any wiring. Env vars that the module
+  under test reads at import time go in the single `unit_test_env` list in
+  that runner.
 
 ## Adding a configuration option (env var)
 
@@ -211,7 +215,7 @@ A new environment variable is never just a code change. The full checklist:
    `common/docker-entrypoint.d/00-check-for-required-env.sh`.
 4. Add it to the env list in `standalone_ubuntu_oss_install.sh`.
 5. Add a pass-through entry in `test/docker-compose.yaml`; if unit tests need
-   it, add it to the unit-test runner env blocks too.
+   it, add it to the `unit_test_env` list in `test/run_unit_tests.sh` too.
 6. Add integration coverage — new settings without tests are historically
    blocked in review.
 
@@ -234,7 +238,8 @@ A new environment variable is never just a code change. The full checklist:
 - Conventional Commits format (`fix:`, `feat:`, `ci:`, `build:` ...), imperative
   mood, subject ≤72 chars — changelogs are generated from these.
 - Shell scripts must pass `shellcheck --severity=warning`; new scripts under
-  `test/integration/` and `common/docker-entrypoint.d/` are linted automatically.
+  `test/` (the runners), `test/integration/`, and `common/docker-entrypoint.d/`
+  are linted automatically.
 - checkmake lints the GNUmakefile and does not follow backslash continuations —
   keep `.PHONY` declarations on a single line.
 - Config/behavior changes usually need matching updates in both `oss/` and

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,9 +23,8 @@ OPEN_CMD          ?= $(shell command -v xdg-open 2> /dev/null || echo open)
 # NOTE: comments must stay on their own line -- GNU make keeps the whitespace
 # before an inline `#` as part of the value, which corrupts docker tags.
 
-# Docker CLI used by the build/clean targets. Caveat: the retest* targets
-# delegate to test.sh, which always uses `docker` from PATH, so pointing this
-# at another CLI (e.g. podman) only affects builds, not the test flows.
+# Docker CLI used by the build, test, and clean targets. Passed through to
+# the test runner scripts under test/.
 DOCKER            ?= docker
 
 # NGINX flavor to build and test: oss or plus
@@ -42,32 +41,35 @@ DOCS_DIR          ?= reference
 # The floating image tag. NOT tunable (override keeps even command-line
 # assignments from changing it): Dockerfile.latest-njs and
 # Dockerfile.unprivileged build FROM this literal name, and
-# test/docker-compose.yaml and test.sh's unit tests run it by this literal
-# name. Parameterize those files before turning this into a knob.
+# test/docker-compose.yaml runs it by this literal name. Parameterize those
+# files before turning this into a knob.
 override IMAGE_NAME := nginx-s3-gateway
 
-# Must match test_compose_project in test.sh
+# Passed through to test/run_integration_tests.sh (which defaults to the
+# same value), so the suite and the `clean` teardown share one project name.
 COMPOSE_PROJECT   := ngt
 COMPOSE_FILE      := $(BASE_DIR)test/docker-compose.yaml
 PLUS_CRT          := $(BASE_DIR)plus/etc/ssl/nginx/nginx-repo.crt
 PLUS_KEY          := $(BASE_DIR)plus/etc/ssl/nginx/nginx-repo.key
 DOCKERFILES       := Dockerfile.oss Dockerfile.plus Dockerfile.latest-njs Dockerfile.unprivileged
-# Wildcards (not `git ls-files`) so new entrypoint/integration scripts are
-# linted automatically while lint still works without git or a .git directory
+# Wildcards (not `git ls-files`) so new entrypoint/test-runner/integration
+# scripts are linted automatically while lint still works without git or a .git directory
 # (release tarballs, docker contexts). Anchored to BASE_DIR and converted back
 # to repo-relative paths because the shellcheck recipe cds into BASE_DIR.
 SHELL_SCRIPTS     := test.sh \
                      standalone_ubuntu_oss_install.sh \
+                     $(patsubst $(BASE_DIR)%,%,$(wildcard $(BASE_DIR)test/*.sh)) \
                      $(patsubst $(BASE_DIR)%,%,$(wildcard $(BASE_DIR)test/integration/*.sh)) \
                      $(patsubst $(BASE_DIR)%,%,$(wildcard $(BASE_DIR)common/docker-entrypoint.d/*.sh)) \
                      $(patsubst $(BASE_DIR)%,%,$(wildcard $(BASE_DIR)common/docker-entrypoint.d/*.envsh))
 
-# Pre-existing shellcheck findings in scripts this Makefile must not modify.
-# Burn this list down when test.sh is refactored into make-native pieces.
-SHELLCHECK_EXCLUDES := SC2027,SC2034,SC2068,SC2120,SC2140
+# Pre-existing shellcheck findings in scripts this Makefile must not modify:
+# SC2027/SC2034/SC2140 in test/integration/test_api.sh and SC2068 in the sh
+# entrypoint/standalone install scripts. New scripts must lint clean.
+SHELLCHECK_EXCLUDES := SC2027,SC2034,SC2068,SC2140
 
 # Single line on purpose: checkmake's parser does not follow continuations
-.PHONY: help check-tools check-nginx-type check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck hadolint docs docs-open jsdoc clean clean-images all ci
+.PHONY: help check-tools check-nginx-type check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck hadolint docs docs-open jsdoc clean clean-images all ci
 
 ##@ Help
 
@@ -145,9 +147,9 @@ build-plus: check-plus-creds ## Build the NGINX Plus gateway image (requires ngi
 # Each variant recipe first pins the floating tag back to the clean
 # :$(NGINX_TYPE) base image, so variants never layer on top of each other --
 # including when both variant targets run in one make invocation, where the
-# phony `build` prerequisite is deduplicated and runs only once.
-# Note: test.sh invoked with both --latest-njs and --unprivileged stacks the
-# two variants; CI never exercises that combination and neither does this file.
+# phony `build` prerequisite is deduplicated and runs only once. Stacking the
+# two variants on one image is deliberately unsupported (CI never exercised
+# that combination when the legacy test.sh still allowed it).
 build-latest-njs: build ## Layer the latest njs build onto the NGINX_TYPE image
 	$(DOCKER) tag $(IMAGE_NAME):$(NGINX_TYPE) $(IMAGE_NAME)
 	cd "$(BASE_DIR)" && $(DOCKER) build -f Dockerfile.latest-njs \
@@ -184,30 +186,63 @@ test-matrix-plus: ## Run the same matrix against NGINX Plus (certs + license.jwt
 
 ##@ Test (no rebuild)
 
-# Single source for the test.sh invocation contract. CI=true makes test.sh
-# skip its internal docker build and run against whatever image is currently
-# tagged as the floating IMAGE_NAME tag; S3_STYLE reaches the integration
-# environment through docker-compose interpolation.
-RUN_TESTS = cd "$(BASE_DIR)" && CI=true S3_STYLE="$(S3_STYLE)" ./test.sh --type $(NGINX_TYPE)
+# Single source for the runner invocation contracts (see the script headers
+# in test/ for the full environment documentation). Both run against whatever
+# image is currently tagged as the floating IMAGE_NAME tag; S3_STYLE reaches
+# the integration environment through docker-compose interpolation. The
+# variant retest targets flip the runners' NJS_LATEST/UNPRIVILEGED knobs
+# (default 0) with an env prefix on the recipe line.
+RUN_UNIT_TESTS = DOCKER="$(DOCKER)" IMAGE_NAME="$(IMAGE_NAME)" \
+	"$(BASE_DIR)test/run_unit_tests.sh"
+RUN_INTEGRATION_TESTS = DOCKER="$(DOCKER)" NGINX_TYPE="$(NGINX_TYPE)" \
+	S3_STYLE="$(S3_STYLE)" COMPOSE_PROJECT="$(COMPOSE_PROJECT)" \
+	"$(BASE_DIR)test/run_integration_tests.sh"
 
-retest: check-nginx-type ## Test the currently tagged image without rebuilding
-	$(RUN_TESTS)
+# Inverse of VARIANT_GUARD below: the non-variant targets must not drive a
+# floating tag that is actually the named variant image, or the run fails
+# bafflingly instead of with this error (unit tests pass the stable
+# `-t module` flag the latest-njs CLI dropped; integration maps host 8989 to
+# port 80 while the unprivileged image listens on 8080). Checked per runner:
+# unit tests only care about the njs flavor, integration only about the port.
+NONVARIANT_GUARD = @variant_id="$$($(DOCKER) image inspect -f '{{.Id}}' $(IMAGE_NAME):$(1)-$(NGINX_TYPE) 2> /dev/null || true)"; \
+	floating_id="$$($(DOCKER) image inspect -f '{{.Id}}' $(IMAGE_NAME) 2> /dev/null || true)"; \
+	if [ -n "$$variant_id" ] && [ "$$floating_id" = "$$variant_id" ]; then \
+	echo "ERROR: '$(IMAGE_NAME)' currently points at the $(1)-$(NGINX_TYPE) variant image; run 'make build' first (or 'make retest-$(1)')"; exit 2; fi
 
-# Guard the variant retests: --latest-njs/--unprivileged change how test.sh
-# drives the image (njs -m unit-test flag, port 8080), so running them against
+test-unit: ## Run only the njs unit tests against the currently tagged image
+	$(call NONVARIANT_GUARD,latest-njs)
+	$(RUN_UNIT_TESTS)
+
+test-integration: check-nginx-type check-tools ## Run only the integration suite against the currently tagged image
+	$(call NONVARIANT_GUARD,unprivileged)
+	$(RUN_INTEGRATION_TESTS)
+
+# check-tools fails fast on a missing integration dependency (mc, curl,
+# compose, md5sum) before the unit suite spends a minute in docker, matching
+# the up-front dependency checks the legacy test.sh ran at startup.
+retest: check-nginx-type check-tools ## Test the currently tagged image without rebuilding
+	$(call NONVARIANT_GUARD,latest-njs)
+	$(call NONVARIANT_GUARD,unprivileged)
+	$(RUN_UNIT_TESTS)
+	$(RUN_INTEGRATION_TESTS)
+
+# Guard the variant retests: NJS_LATEST/UNPRIVILEGED change how the runners
+# drive the image (njs -m unit-test flag, port 8080), so running them against
 # a non-variant floating tag produces baffling failures instead of this error.
 VARIANT_GUARD = @variant_id="$$($(DOCKER) image inspect -f '{{.Id}}' $(IMAGE_NAME):$(1)-$(NGINX_TYPE) 2> /dev/null || true)"; \
 	floating_id="$$($(DOCKER) image inspect -f '{{.Id}}' $(IMAGE_NAME) 2> /dev/null || true)"; \
 	{ [ -n "$$variant_id" ] && [ "$$floating_id" = "$$variant_id" ]; } || { \
 	echo "ERROR: '$(IMAGE_NAME)' is not the $(1)-$(NGINX_TYPE) variant image; run 'make build-$(1)' (or 'make test-$(1)') first"; exit 2; }
 
-retest-latest-njs: check-nginx-type ## Test the current image with latest-njs semantics, no rebuild
+retest-latest-njs: check-nginx-type check-tools ## Test the current image with latest-njs semantics, no rebuild
 	$(call VARIANT_GUARD,latest-njs)
-	$(RUN_TESTS) --latest-njs
+	NJS_LATEST=1 $(RUN_UNIT_TESTS)
+	$(RUN_INTEGRATION_TESTS)
 
-retest-unprivileged: check-nginx-type ## Test the current image in unprivileged mode, no rebuild
+retest-unprivileged: check-nginx-type check-tools ## Test the current image in unprivileged mode, no rebuild
 	$(call VARIANT_GUARD,unprivileged)
-	$(RUN_TESTS) --unprivileged
+	$(RUN_UNIT_TESTS)
+	UNPRIVILEGED=1 $(RUN_INTEGRATION_TESTS)
 
 ##@ Lint
 
@@ -230,9 +265,8 @@ hadolint: ## Lint Dockerfiles with hadolint when installed (opt-in, not part of 
 
 ##@ Documentation
 
-# NOTE: jsdoc exits non-zero on template warnings; the legacy `|| true`
-# suppression is retained so doc generation stays best-effort. Revisit
-# during the test.sh refactor phase.
+# NOTE: jsdoc exits non-zero on template warnings; the `|| true` suppression
+# keeps doc generation best-effort so warnings never fail `make all`.
 docs: ## Generate JSDoc reference documentation into DOCS_DIR
 	cd "$(BASE_DIR)" && npx jsdoc -c jsdoc/conf.json -d "$(DOCS_DIR)" || true
 
@@ -246,8 +280,9 @@ jsdoc: docs ## Back-compat alias for docs (previous Makefile's target name)
 # The DOCS_DIR guard rejects empty, absolute, parent-traversal, and
 # trailing-slash values so the rm -rf can never escape the repository (a
 # trailing slash would make rm follow a symlinked DOCS_DIR into its target).
-# The teardown mirrors test.sh's compose() invocation, including its
-# docker-compose fallback, and also removes the mc alias test.sh registers.
+# The teardown mirrors the compose() invocation in
+# test/run_integration_tests.sh, including its docker-compose fallback, and
+# also removes the mc alias that script registers.
 clean: ## Remove generated docs and tear down the test compose environment
 	@case "$(DOCS_DIR)" in \
 		""|.|..|/*|*..*|*/) echo "ERROR: refusing to rm -rf suspicious DOCS_DIR '$(DOCS_DIR)'"; exit 1;; \

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ GNUmakefile                      entry point for all build, test, and lint workf
 package.json                     Node.js package file used only for generating JSDoc
 settings.example                 Docker env file example
 standalone_ubuntu_oss_install.sh install script that will install the gateway as a Systemd service
-test.sh                          legacy test launcher, superseded by `make test` - do not
-                                 invoke directly
+test.sh                          deprecated wrapper that forwards to the equivalent make
+                                 targets - do not invoke directly
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ examples/                        contains additional `Dockerfile` examples that 
 jsdoc                            JSDoc configuration files
 oss/                             contains files used solely in NGINX OSS configurations
 plus/                            contains files used solely in NGINX Plus configurations
-test/                            contains automated tests for validang that the examples work
+test/                            contains the test runner scripts (run_unit_tests.sh and
+                                 run_integration_tests.sh, both driven by make) plus the njs
+                                 unit tests and bash integration tests they execute
 Dockerfile.oss                   Dockerfile that configures NGINX OSS to act as a S3 gateway
 Dockerfile.plus                  Dockerfile that builds a NGINX Plus instance that is configured
                                  equivelently to NGINX OSS - instance is configured to act as a
                                  S3 gateway with NGINX Plus additional features enabled
-Dockerfile.buildkit.plus         Dockerfile with the same configuration as Dockerfile.plus, but
-                                 with support for hiding secrets using Docker's Buildkit
 Dockerfile.latest-njs            Dockerfile that inherits from the last build of the gateway and
                                  then builds and installs the latest version of njs from source
 Dockerfile.unprivileged          Dockerfiles that inherits from the last build of the gateway and

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,8 +56,10 @@ additional modules.
 ## Testing
 
 The `GNUmakefile` (GNU Make 4.x) is the only supported interface for build and
-test workflows. The legacy `test.sh` script still exists underneath, but it is
-being migrated away from — do not invoke it directly.
+test workflows. The test logic lives in `test/run_unit_tests.sh` and
+`test/run_integration_tests.sh`, which make drives; the legacy `test.sh`
+script is deprecated and only forwards to the equivalent make targets — do
+not invoke it directly.
 
 Automated tests require `docker`, `docker compose`, `curl`, `md5sum` (or `md5`
 on macOS), and `mc` (the
@@ -82,6 +84,8 @@ Other useful targets:
 * `make retest` — rerun tests against the already-built image. Note that unit
   tests import the njs modules baked into the image, so after editing
   `common/etc/nginx/include/*.js` use `make test` to rebuild first.
+* `make test-unit` / `make test-integration` — run just the unit or just the
+  integration half of the suite against the already-built image.
 * `make test-latest-njs` / `make test-unprivileged` — build and test the
   image variants.
 * `make test-matrix` — reproduce the CI matrix locally.

--- a/docs/development.md
+++ b/docs/development.md
@@ -92,3 +92,25 @@ Other useful targets:
 * `make lint` — run the linters (checkmake + shellcheck).
 
 Run `make help` for the full target list.
+
+### Adding tests
+
+Unit tests live in `test/unit/` and run under the njs CLI inside the built
+image. New files are discovered automatically: `test/run_unit_tests.sh` runs
+every `test/unit/*_test.js` file twice — once with and once without
+`AWS_SESSION_TOKEN` — so no wiring is needed. Environment variables that a
+module under test reads at import time belong in the `unit_test_env` list in
+that runner.
+
+Integration tests live in `test/integration/` and are driven by
+`test/run_integration_tests.sh`, which starts the compose environment
+(`test/docker-compose.yaml`), seeds MinIO with the fixtures in `test/data/`,
+and invokes the test scripts across a matrix of gateway configurations. New
+shell scripts under `test/` and `test/integration/` are picked up by
+`make lint` automatically and must pass `shellcheck --severity=warning`.
+
+The make targets guard against image/target mismatches: the variant targets
+(`retest-latest-njs`, `retest-unprivileged`) verify the floating
+`nginx-s3-gateway` tag actually points at the matching variant image, and the
+non-variant targets verify the inverse, failing with an actionable error
+instead of a confusing test failure.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -272,18 +272,20 @@ docker run --env-file ./settings --publish 8080:8080 --name nginx-s3-gateway \
 
 ### Building the Public Open Source NGINX Container Image
 
-In order to build the NGINX OSS container image, do a `docker build` as follows
-from the project root directory:
+The `GNUmakefile` (GNU Make 4.x) is the supported interface for building the
+gateway. To build the NGINX OSS container image, run the following from the
+project root directory:
 
 ```
-docker build --file Dockerfile.oss --tag nginx-s3-gateway:oss --tag nginx-s3-gateway .
+make build
 ```
 
-Alternatively, if you would like to use the latest version of
-[njs](https://nginx.org/en/docs/njs/), you can build an image from the latest 
-njs source by building this image after building the parent image above:
+This tags the image as `nginx-s3-gateway` and `nginx-s3-gateway:oss` (the
+underlying Dockerfile is `Dockerfile.oss`). Alternatively, if you would like
+to use the latest version of [njs](https://nginx.org/en/docs/njs/), you can
+layer a build of njs from the latest source on top of the image above:
 ```
-docker build --file Dockerfile.oss --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-oss .
+make build-latest-njs
 ```
 
 After building, you can run the image by issuing the following command and 
@@ -297,7 +299,7 @@ docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
 In the same way, if you want to use NGINX OSS container image as a non-root, unprivileged user,
 you can build it as follows:
 ```
-docker build --file Dockerfile.unprivileged --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-oss .
+make build-unprivileged
 ```
 And run the image binding the container port 8080 to 80 in the host like:
 ```
@@ -309,23 +311,25 @@ It is worth noting that due to the way the startup scripts work, even the unpriv
 
 ### Building the NGINX Plus Container Image
 
-In order to build the NGINX Plus container image, you will need to set up the official NGINX
-Plus Docker image repository, as [per the documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-docker/#use-official-nginx-plus-docker-images).
+In order to build the NGINX Plus container image, copy your NGINX Plus
+repository certificate and key (`nginx-repo.crt` and `nginx-repo.key`) into
+the `plus/etc/ssl/nginx/` directory, and set up access to the official NGINX
+Plus Docker image repository (`docker login private-registry.nginx.com`), as
+[per the documentation](https://docs.nginx.com/nginx/admin-guide/installing-nginx/installing-nginx-docker/#use-official-nginx-plus-docker-images).
 
 To build, run the following from the project root directory:
 
 ```
-docker buildx build \
-    --file Dockerfile.plus \
-    --tag nginx-plus-s3-gateway --tag nginx-plus-s3-gateway:plus .
+make build NGINX_TYPE=plus
 ```
 
-Alternatively, if you would like to use the latest version of
-[njs](https://nginx.org/en/docs/njs/) with NGINX Plus, you can build an image
-from the latest njs source by building this image after building the parent 
-image above:
+This tags the image as `nginx-s3-gateway` and `nginx-s3-gateway:plus` (the
+underlying Dockerfile is `Dockerfile.plus`). Alternatively, if you would like
+to use the latest version of [njs](https://nginx.org/en/docs/njs/) with NGINX
+Plus, you can layer a build of njs from the latest source on top of the image
+above:
 ```
-docker build --file Dockerfile.latest-njs --tag nginx-plus-s3-gateway:latest-njs-plus .
+make build-latest-njs NGINX_TYPE=plus
 ```
 
 After building, you can run the image by issuing the following command and
@@ -333,7 +337,7 @@ replacing the path to the `settings` file with a file containing your specific
 environment variables.
 ```
 docker run --env-file ./settings --publish 80:80 --name nginx-plus-s3-gateway \
-    nginx-plus-s3-gateway:plus
+    nginx-s3-gateway:plus
 ```
 
 ## Running Using AWS Instance Profile Credentials

--- a/examples/brotli-compression/Dockerfile.plus
+++ b/examples/brotli-compression/Dockerfile.plus
@@ -1,4 +1,5 @@
-FROM nginx-plus-s3-gateway
+# The :plus tag is produced by `make build NGINX_TYPE=plus` (see docs/getting_started.md)
+FROM nginx-s3-gateway:plus
 
 # Install Brolti from the NGINX Plus repository
 RUN set -eux \

--- a/examples/gzip-compression/Dockerfile.plus
+++ b/examples/gzip-compression/Dockerfile.plus
@@ -1,3 +1,4 @@
-FROM nginx-plus-s3-gateway
+# The :plus tag is produced by `make build NGINX_TYPE=plus` (see docs/getting_started.md)
+FROM nginx-s3-gateway:plus
 
 COPY etc/nginx/conf.d /etc/nginx/conf.d

--- a/examples/modsecurity/Dockerfile.plus
+++ b/examples/modsecurity/Dockerfile.plus
@@ -1,4 +1,5 @@
-FROM nginx-plus-s3-gateway
+# The :plus tag is produced by `make build NGINX_TYPE=plus` (see docs/getting_started.md)
+FROM nginx-s3-gateway:plus
 
 ENV OWASP_RULESET_VERSION "v3.3.0"
 ENV OWASP_RULESET_CHECKSUM "1f4002b5cf941a9172b6250cea7e3465a85ef6ee"

--- a/test.sh
+++ b/test.sh
@@ -16,60 +16,35 @@
 #  limitations under the License.
 #
 
-set -o errexit   # abort on nonzero exit status
-set -o pipefail  # don't hide errors within pipes
-
-### Overview
-# This script does three things:
-# 1. Sets up the test environment using docker-compose and creates test data
-# 2. Runs unit tests in the ./test/unit directory which are written in Javascript
-# 3. Runs integration tests in ./test/integration which are written in bash
+# DEPRECATED: this script is retained only for backwards compatibility and
+# now delegates to the GNUmakefile, which is the sole supported interface for
+# build and test workflows. Use the make targets directly instead:
 #
-# The integration test runner uses a series of flags to test different configuration
-# values. See the function definition for `integration_test` in this file
-# for details on the parameters and their allowed values.
+#   ./test.sh --type oss            ->  make test  NGINX_TYPE=oss
+#   CI=true ./test.sh --type oss    ->  make retest NGINX_TYPE=oss
+#   ./test.sh --latest-njs ...      ->  make test-latest-njs / retest-latest-njs
+#   ./test.sh --unprivileged ...    ->  make test-unprivileged / retest-unprivileged
+#
+# Run `make help` for the full target list. The test logic itself lives in
+# test/run_unit_tests.sh and test/run_integration_tests.sh.
 
-nginx_server_proto="http"
-nginx_server_host="localhost"
-nginx_server_port="8989"
-
-test_server="${nginx_server_proto}://${nginx_server_host}:${nginx_server_port}"
-test_fail_exit_code=2
-no_dep_exit_code=3
-build_dep_exit_code=4
+set -o errexit
+set -o nounset
+set -o pipefail
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-test_dir="${script_dir}/test"
-test_compose_config="${test_dir}/docker-compose.yaml"
-test_compose_project="ngt"
-
-minio_server="http://localhost:9090"
-minio_user="AKIAIOSFODNN7EXAMPLE"
-minio_passwd="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-minio_name="${test_compose_project}_minio_1"
-minio_bucket="bucket-1"
-CI=${CI:="false"}
-
-is_windows="0"
-if [ -z "${OS}" ] && [ "${OS}" == "Windows_NT" ]; then
-  is_windows="1"
-elif command -v uname > /dev/null; then
-  uname_output="$(uname -s)"
-  if [[ "${uname_output}" == *"_NT-"* ]]; then
-    is_windows="1"
-  fi
-fi
-
-p() {
-  printf "\033[34;1m▶\033[0m "
-  echo "$1"
-}
 
 e() {
   >&2 echo "$1"
 }
 
-usage() { e "Usage: $0 [--latest-njs <default:false>] [--unprivileged <default:false>] [--type <default:oss|plus>" 1>&2; exit 1; }
+usage() {
+  e "Usage: $0 [--latest-njs] [--unprivileged] [--type <oss|plus>]"
+  exit 1
+}
+
+e "WARNING: test.sh is deprecated and now delegates to make."
+e "         Use the make targets directly - run 'make help' for the list."
 
 for arg in "$@"; do
   shift
@@ -82,534 +57,47 @@ for arg in "$@"; do
   esac
 done
 
+njs_latest=0
+unprivileged=0
+nginx_type="oss"
+
 while getopts "hjut:" arg; do
-    case "${arg}" in
-        j)
-            njs_latest="1"
-            ;;
-        u)
-            unprivileged="1"
-            ;;
-        t)
-            nginx_type="${OPTARG}"
-            ;;
-        *)
-            usage
-            ;;
-    esac
+  case "${arg}" in
+    j) njs_latest=1 ;;
+    u) unprivileged=1 ;;
+    t) nginx_type="${OPTARG}" ;;
+    *) usage ;;
+  esac
 done
 shift $((OPTIND-1))
 
-startup_message=""
+# The legacy script stacked the two variants onto one image when both flags
+# were given; the make targets deliberately do not support that combination.
+if [ "${njs_latest}" -eq 1 ] && [ "${unprivileged}" -eq 1 ]; then
+  e "Combining --latest-njs and --unprivileged is no longer supported;"
+  e "run 'make test-latest-njs' and 'make test-unprivileged' separately."
+  exit 1
+fi
 
-if [ -z "${nginx_type}" ]; then
-  nginx_type="oss"
-  startup_message="Starting NGINX ${nginx_type} (default)"
-elif ! { [ ${nginx_type} == "oss" ] || [ ${nginx_type} == "plus" ]; }; then
-    e "Invalid NGINX type: ${nginx_type} - must be either 'oss' or 'plus'"
-    usage
+variant=""
+if [ "${njs_latest}" -eq 1 ]; then
+  variant="-latest-njs"
+elif [ "${unprivileged}" -eq 1 ]; then
+  variant="-unprivileged"
+fi
+
+# The legacy contract: CI=true skipped the docker build and tested the image
+# already tagged nginx-s3-gateway. That maps to the no-rebuild retest targets.
+if [ "${CI:-false}" = "true" ]; then
+  target="retest${variant}"
 else
-  startup_message="Starting NGINX ${nginx_type}"
+  target="test${variant}"
 fi
 
-if [ -z "${njs_latest}" ]; then
-  njs_latest="0"
-  startup_message="${startup_message} with the release NJS module (default)"
-elif [ ${njs_latest} -eq 1 ]; then
-  startup_message="${startup_message} with the latest NJS module"
-else
-  startup_message="${startup_message} with the release NJS module"
+make_args=("${target}" "NGINX_TYPE=${nginx_type}")
+if [ -n "${S3_STYLE:-}" ]; then
+  make_args+=("S3_STYLE=${S3_STYLE}")
 fi
 
-if [ -z "${unprivileged}" ]; then
-  unprivileged="0"
-  startup_message="${startup_message} in privileged mode (default)"
-elif [ ${unprivileged} -eq 1 ]; then
-  startup_message="${startup_message} in unprivileged mode"
-else
-  startup_message="${startup_message} in privileged mode"
-fi
-
-# The unprivileged image rewrites 'listen 80;' to 'listen 8080;' at build
-# time (Dockerfile.unprivileged); every listen-related assertion keys off
-# this single value.
-if [ ${unprivileged} -eq 1 ]; then
-  gateway_listen_port=8080
-else
-  gateway_listen_port=80
-fi
-
-e "${startup_message}"
-
-set -o nounset   # abort on unbound variable
-
-docker_cmd="$(command -v docker || true)"
-if ! [ -x "${docker_cmd}" ]; then
-  e "required dependency not found: docker not found in the path or not executable"
-  exit ${no_dep_exit_code}
-fi
-
-if docker compose > /dev/null; then
-  docker_compose_cmd="docker compose"
-elif command -v docker-compose > /dev/null; then
-  docker_compose_cmd="docker-compose"
-else
-  e "required dependency not found: docker-compose not found in the path or not executable"
-  exit ${no_dep_exit_code}
-fi
-e "Using Docker Compose command: ${docker_compose_cmd}"
-
-curl_cmd="$(command -v curl || true)"
-if ! [ -x "${curl_cmd}" ]; then
-  e "required dependency not found: curl not found in the path or not executable"
-  exit ${no_dep_exit_code}
-fi
-
-if command -v mc > /dev/null; then
-  mc_cmd="$(command -v mc)"
-elif [ -x "${script_dir}/.bin/mc" ]; then
-  mc_cmd="${script_dir}/.bin/mc"
-else
-  e "required dependency not found: mc not found in the path or not executable"
-  exit ${no_dep_exit_code}
-fi
-e "Using MinIO Client: ${mc_cmd}"
-
-if ! [ -x "${mc_cmd}" ]; then
-  e "required dependency not found: mc not found in the path or not executable"
-  exit ${no_dep_exit_code}
-fi
-
-wait_for_it_cmd="$(command -v wait-for-it || true)"
-if [ -x "${wait_for_it_cmd}" ]; then
-  wait_for_it_installed=1
-else
-  e "wait-for-it command not available, consider installing to prevent race conditions"
-  wait_for_it_installed=0
-fi
-
-if [ "${nginx_type}" = "plus" ]; then
-  if [ ! -f "./plus/etc/ssl/nginx/nginx-repo.crt" ]; then
-    e "NGINX Plus certificate file not found: $(pwd)/plus/etc/ssl/nginx/nginx-repo.crt"
-    exit ${no_dep_exit_code}
-  fi
-
-    if [ ! -f "./plus/etc/ssl/nginx/nginx-repo.key" ]; then
-    e "NGINX Plus key file not found: $(pwd)/plus/etc/ssl/nginx/nginx-repo.key"
-    exit ${no_dep_exit_code}
-  fi
-fi
-
-compose() {
-  # Hint to docker-compose the internal port to map for the container
-  if [ ${unprivileged} -eq 1 ]; then
-    export NGINX_INTERNAL_PORT=8080
-  else
-    export NGINX_INTERNAL_PORT=80
-  fi
-
-  if [ "${nginx_type}" == "plus" ]; then
-    if [ -f /etc/nginx/license.jwt ]; then
-      NGINX_LICENSE_JWT="$(cat /etc/nginx/license.jwt)"
-    elif [ -f license.jwt ]; then
-      NGINX_LICENSE_JWT="$(cat license.jwt)"
-    else
-      e "NGINX Plus license file not found: /etc/nginx/license.jwt or $(pwd)/license.jwt"
-      exit ${build_dep_exit_code}
-    fi
-
-  else
-      NGINX_LICENSE_JWT=""
-  fi
-
-  export NGINX_LICENSE_JWT
-
-  ${docker_compose_cmd} -f "${test_compose_config}" -p "${test_compose_project}" "$@"
-}
-
-integration_test_data() {
-
-  # Write problematic files to disk if we are not on Windows. Originally,
-  # these files were checked in, but that prevented the git repository from
-  # being cloned on Windows machines.
-  if [ "$is_windows" == "0" ]; then
-    echo "Writing weird filename: ${test_dir}/data/bucket-1/a/%@!*()=$#^&|.txt"
-    echo 'We are but selling water next to a river.' > "${test_dir}"'/data/bucket-1/a/%@!*()=$#^&|.txt'
-  fi
-
-  p "Starting Docker Compose Environment"
-  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true compose up -d
-
-  if [ "${wait_for_it_installed}" ]; then
-    # Hit minio's health check end point to see if it has started up
-    for (( i=1; i<=3; i++ ))
-    do
-      echo "Querying minio server to see if it is ready"
-      minio_is_up="$(${curl_cmd} -s -o /dev/null -w '%{http_code}' "${minio_server}"/minio/health/cluster)"
-      if [ "${minio_is_up}" = "200" ]; then
-        break
-      else
-        sleep 2
-      fi
-    done
-  fi
-
-  p "Adding test data to container"
-  "${mc_cmd}" alias set "$minio_name" "$minio_server" "$minio_user" "$minio_passwd"
-  "${mc_cmd}" mb "$minio_name/$minio_bucket"
-  echo "Copying contents of ${test_dir}/data/$minio_bucket to Docker container $minio_name"
-  for file in "${test_dir}/data/$minio_bucket"/*; do
-    "${mc_cmd}" cp -r "${file}" "$minio_name/$minio_bucket"
-  done
-  echo "Docker diff output:"
-  "${docker_cmd}" diff "$minio_name"
-}
-
-integration_test_listen_directives() {
-  p "Verifying rendered listen directives"
-  expected_listen_port="${gateway_listen_port}"
-  rendered_conf="$(compose exec -T nginx-s3-gateway cat /etc/nginx/conf.d/default.conf)"
-  if ! echo "${rendered_conf}" | grep -q "listen[[:space:]]*${expected_listen_port};"; then
-    e "rendered default.conf is missing the IPv4 listen directive"
-    exit "$test_fail_exit_code"
-  fi
-  # 02-ipv6-enable.sh injects the IPv6 listen directive only when the
-  # container kernel supports IPv6, so assert against the same condition.
-  if compose exec -T nginx-s3-gateway test -f /proc/net/if_inet6; then
-    if ! echo "${rendered_conf}" | grep -q "listen[[:space:]]*\[::\]:${expected_listen_port};"; then
-      e "container kernel supports IPv6 but rendered default.conf has no IPv6 listen directive"
-      exit "$test_fail_exit_code"
-    fi
-  elif echo "${rendered_conf}" | grep -q "\[::\]"; then
-    e "container kernel lacks IPv6 but rendered default.conf has an IPv6 listen directive"
-    exit "$test_fail_exit_code"
-  fi
-}
-
-integration_test() {
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite for v%s signatures\e[22m\n" "$1"
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with ALLOW_DIRECTORY_LIST=%s\e[22m\n" "$2"
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with PROVIDE_INDEX_PAGE=%s\e[22m\n" "$3"
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=%s\e[22m\n" "$4"
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with STRIP_LEADING_DIRECTORY_PATH=%s\e[22m\n" "$5"
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with PREFIX_LEADING_DIRECTORY_PATH=%s\e[22m\n" "$6"
-
-
-  p "Starting Docker Compose Environment"
-  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=$1 ALLOW_DIRECTORY_LIST=$2 PROVIDE_INDEX_PAGE=$3 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 STRIP_LEADING_DIRECTORY_PATH=$5 PREFIX_LEADING_DIRECTORY_PATH=$6 compose up -d
-
-  if [ "${wait_for_it_installed}" ]; then
-    if [ -x "${wait_for_it_cmd}" ]; then
-      "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
-    fi
-  fi
-
-  p "Starting HTTP API tests (v$1 signatures)"
-  echo "  test/integration/test_api.sh \"$test_server\" \"$test_dir\" $1 $2 $3 $4 $5 $6"
-  bash "${test_dir}/integration/test_api.sh" "${test_server}" "${test_dir}" "$1" "$2" "$3" "$4" "$5" "$6";
-
-  # We check to see if NGINX is in fact using the correct version of AWS
-  # signatures as it was configured to do.
-  sig_versions_found_count=$(compose logs nginx-s3-gateway | grep -c "AWS Signatures Version: v$1\|AWS v$1 Auth")
-
-  if [ "${sig_versions_found_count}" -lt 3 ]; then
-    e "NGINX was not detected as using the correct signatures version - examine logs"
-    compose logs nginx-s3-gateway
-    exit "$test_fail_exit_code"
-  fi
-}
-
-integration_test_cache_bypass() {
-  bypass_setting=$1  # "false" or "true" - passed through compose to the gateway
-  # The assertion set follows the setting so that the two can never be passed
-  # as a mismatched pair.
-  if [ "${bypass_setting}" = "true" ]; then
-    bypass_phase="enabled"
-  else
-    bypass_phase="disabled"
-  fi
-
-  printf "\033[34;1m▶\033[0m"
-  printf "\e[1m Integration test suite with PROXY_CACHE_BYPASS_NO_CACHE=%s\e[22m\n" "${bypass_setting}"
-
-  p "Starting Docker Compose Environment"
-  # The six standard configuration values are pinned to a known baseline
-  # (the v4 signatures, no-listing configuration) so that URL rewriting
-  # configured by the STRIP/PREFIX_LEADING_DIRECTORY_PATH passes cannot leak
-  # in. Changing the environment makes compose recreate the gateway
-  # container, which discards the proxy cache so that each phase starts with
-  # an empty cache.
-  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" PROXY_CACHE_BYPASS_NO_CACHE="${bypass_setting}" compose up -d
-
-  if [ "${wait_for_it_installed}" ]; then
-    if [ -x "${wait_for_it_cmd}" ]; then
-      "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
-    fi
-  fi
-
-  p "Starting cache bypass tests (phase: ${bypass_phase})"
-  echo "  test/integration/test_cache_bypass.sh \"$test_server\" \"$test_dir\" ${bypass_phase} \"${mc_cmd}\" \"${minio_name}\" \"${minio_bucket}\""
-  bash "${test_dir}/integration/test_cache_bypass.sh" "${test_server}" "${test_dir}" "${bypass_phase}" "${mc_cmd}" "${minio_name}" "${minio_bucket}"
-}
-
-finish() {
-  result=$?
-
-  if [ $result -ne 0 ]; then
-    e "Error running tests - outputting container logs"
-    compose logs
-  fi
-
-  p "Cleaning up Docker compose environment"
-  compose stop
-  compose rm -f -v
-  "${mc_cmd}" alias rm "$minio_name"
-
-  exit ${result}
-}
-trap finish EXIT ERR SIGTERM SIGINT
-
-### BUILD
-
-if [ "$CI" = "true" ]; then
-    echo "Skipping docker image build due to CI=true"
-else
-  p "Building NGINX S3 gateway Docker image"
-  if [ "${nginx_type}" = "plus" ]; then
-    if docker buildx > /dev/null 2>&1; then
-      p "Building using BuildKit"
-      export DOCKER_BUILDKIT=1
-      docker buildx build -f "Dockerfile.${nginx_type}" \
-        --secret id=nginx-crt,src=plus/etc/ssl/nginx/nginx-repo.crt \
-        --secret id=nginx-key,src=plus/etc/ssl/nginx/nginx-repo.key \
-        --tag nginx-s3-gateway --tag "nginx-s3-gateway:${nginx_type}" .
-    else
-      e "Only BuildKit builds are supported with NGINX Plus image"
-      exit ${build_dep_exit_code}
-    fi
-  else
-    docker build -f "Dockerfile.${nginx_type}" \
-      --tag nginx-s3-gateway --tag "nginx-s3-gateway:${nginx_type}" .
-  fi
-
-  if [ ${njs_latest} -eq 1 ]; then
-    p "Layering in latest NJS build"
-    docker build -f Dockerfile.latest-njs \
-      --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
-  fi
-
-  if [ ${unprivileged} -eq 1 ]; then
-    p "Layering in unprivileged build"
-    docker build -f Dockerfile.unprivileged \
-      --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-${nginx_type} .
-  fi
-fi
-
-### UNIT TESTS
-
-runUnitTestWithOutSessionToken() {
-  test_code="$1"
-  # Temporary hack while njs transitions to supporting -m in the cli tool
-  if [ ${njs_latest} -eq 1 ]
-    then
-      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-        --rm                                  \
-        -v "$(pwd)/test/unit:/var/tmp"        \
-        --workdir /var/tmp                    \
-        -e "DEBUG=true"                       \
-        -e "S3_STYLE=virtual-v2"                 \
-        -e "S3_SERVICE=s3"                    \
-        -e "AWS_ACCESS_KEY_ID=unit_test"      \
-        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-        -e "S3_BUCKET_NAME=unit_test"         \
-        -e "S3_SERVER=unit_test"              \
-        -e "S3_SERVER_PROTO=https"            \
-        -e "S3_SERVER_PORT=443"               \
-        -e "S3_REGION=test-1"                 \
-        -e "AWS_SIGS_VERSION=4"               \
-        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
-        --entrypoint /usr/bin/njs             \
-        nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
-    else
-      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-        --rm                                  \
-        -v "$(pwd)/test/unit:/var/tmp"        \
-        --workdir /var/tmp                    \
-        -e "DEBUG=true"                       \
-        -e "S3_STYLE=virtual-v2"                 \
-        -e "S3_SERVICE=s3"                    \
-        -e "AWS_ACCESS_KEY_ID=unit_test"      \
-        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-        -e "S3_BUCKET_NAME=unit_test"         \
-        -e "S3_SERVER=unit_test"              \
-        -e "S3_SERVER_PROTO=https"            \
-        -e "S3_SERVER_PORT=443"               \
-        -e "S3_REGION=test-1"                 \
-        -e "AWS_SIGS_VERSION=4"               \
-        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
-        --entrypoint /usr/bin/njs             \
-        nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
-  fi
-}
-
-runUnitTestWithSessionToken() {
-  test_code="$1"
-  # Temporary hack while njs transitions to supporting -m in the cli tool
-  if [ ${njs_latest} -eq 1 ]
-    then
-      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-        --rm                                  \
-        -v "$(pwd)/test/unit:/var/tmp"        \
-        --workdir /var/tmp                    \
-        -e "DEBUG=true"                       \
-        -e "S3_STYLE=virtual-v2"                 \
-        -e "S3_SERVICE=s3"                    \
-        -e "AWS_ACCESS_KEY_ID=unit_test"      \
-        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-        -e "AWS_SESSION_TOKEN=unit_test"      \
-        -e "S3_BUCKET_NAME=unit_test"         \
-        -e "S3_SERVER=unit_test"              \
-        -e "S3_SERVER_PROTO=https"            \
-        -e "S3_SERVER_PORT=443"               \
-        -e "S3_REGION=test-1"                 \
-        -e "AWS_SIGS_VERSION=4"               \
-        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
-        --entrypoint /usr/bin/njs             \
-        nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
-    else
-      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-        --rm                                  \
-        -v "$(pwd)/test/unit:/var/tmp"        \
-        --workdir /var/tmp                    \
-        -e "DEBUG=true"                       \
-        -e "S3_STYLE=virtual-v2"                 \
-        -e "S3_SERVICE=s3"                    \
-        -e "AWS_ACCESS_KEY_ID=unit_test"      \
-        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-        -e "AWS_SESSION_TOKEN=unit_test"      \
-        -e "S3_BUCKET_NAME=unit_test"         \
-        -e "S3_SERVER=unit_test"              \
-        -e "S3_SERVER_PROTO=https"            \
-        -e "S3_SERVER_PORT=443"               \
-        -e "S3_REGION=test-1"                 \
-        -e "AWS_SIGS_VERSION=4"               \
-        -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true" \
-        --entrypoint /usr/bin/njs             \
-        nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
-  fi
-}
-
-p "Running unit tests for utils"
-runUnitTestWithSessionToken "utils_test.js"
-
-p "Running unit tests with an access key ID and a secret key in Docker image"
-runUnitTestWithOutSessionToken "awscredentials_test.js"
-runUnitTestWithOutSessionToken "awssig2_test.js"
-runUnitTestWithOutSessionToken "awssig4_test.js"
-runUnitTestWithOutSessionToken "s3gateway_test.js"
-
-p "Running unit tests with an session token in Docker image"
-runUnitTestWithSessionToken "awscredentials_test.js"
-runUnitTestWithSessionToken "awssig2_test.js"
-runUnitTestWithSessionToken "awssig4_test.js"
-runUnitTestWithSessionToken "s3gateway_test.js"
-
-p "Testing IPv6 entrypoint script"
-bash "${test_dir}/integration/test_entrypoint_ipv6.sh" "${docker_cmd}" "${gateway_listen_port}"
-
-p "Testing settings output entrypoint script"
-bash "${test_dir}/integration/test_entrypoint_output_settings.sh" "${docker_cmd}"
-
-### INTEGRATION TESTS
-# The arguments correspond to flags given to the integration test runner
-# integration_test 2 0 0 0
-# AWS_SIGS_VERSION=$1 : any valid AWS Sigs version. Supported values are `2` or `4`
-# ALLOW_DIRECTORY_LIST=$2 : boolean value denoted by `0` or `1`
-# PROVIDE_INDEX_PAGE=$3 : boolean value denoted by `0` or `1`
-# APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 : boolean value denoted by `0` or `1`
-#
-# These are various invocations of ./test/integration/test_api.sh
-# where the flags represent different configurations for that single test
-# file.
-
-integration_test_data
-
-p "Testing API with AWS Signature V2 and allow directory listing off"
-integration_test 2 0 0 0 "" ""
-
-integration_test_listen_directives
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing API with AWS Signature V2 and allow directory listing on"
-integration_test 2 1 0 0 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing API with AWS Signature V2 and static site on"
-integration_test 2 0 1 0 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing API with AWS Signature V2 and allow directory listing on and append slash and allow index"
-integration_test 2 1 1 1 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Test API with AWS Signature V4 and allow directory listing off"
-integration_test 4 0 0 0 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Test API with AWS Signature V4 and allow directory listing on and appending /"
-integration_test 4 1 0 1 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Test API with AWS Signature V4 and static site on appending /"
-integration_test 4 0 1 1 "" ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing API with AWS Signature V2 and allow directory listing off and prefix stripping on"
-integration_test 2 0 0 0 /my-bucket ""
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Test API with AWS Signature V4 and prefix leading directory path on"
-integration_test 4 0 0 0 "" "/b"
-
-p "Test API with AWS Signature V4 and prefix leading directory path on and prefix stripping on"
-integration_test 4 0 0 0 "/tostrip" "/b"
-
-p "Testing API with AWS Signature V2 and prefix leading directory path"
-integration_test 2 0 0 0 "" "/b"
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing proxy cache bypass with PROXY_CACHE_BYPASS_NO_CACHE=false (default)"
-integration_test_cache_bypass "false"
-
-compose stop nginx-s3-gateway # Restart with new config
-
-p "Testing proxy cache bypass with PROXY_CACHE_BYPASS_NO_CACHE=true"
-integration_test_cache_bypass "true"
-
-p "All integration tests complete"
+e "Delegating to: make -C ${script_dir} ${make_args[*]}"
+exec make -C "${script_dir}" "${make_args[@]}"

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright 2026 F5, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Runs the integration test suite against an already-built gateway image
+# using the docker compose environment in test/docker-compose.yaml. Invoked
+# by the GNUmakefile (make test-integration / make retest) - not intended to
+# be run directly, although doing so is harmless.
+#
+# The suite starts MinIO plus the gateway, seeds test data, then drives
+# test/integration/test_api.sh and test_cache_bypass.sh through a matrix of
+# gateway configurations. The entrypoint-script tests run first since they
+# only need the image, not the compose environment.
+#
+# Environment:
+#   DOCKER           docker CLI to use (default: docker)
+#   NGINX_TYPE       oss or plus (default: oss); plus requires a license.jwt
+#                    at /etc/nginx/license.jwt or the repository root
+#   UNPRIVILEGED     1 when testing the unprivileged variant image, which
+#                    listens on 8080 instead of 80 (default: 0)
+#   S3_STYLE         S3 addressing style under test - reaches the gateway
+#                    through docker-compose interpolation, whose
+#                    ${S3_STYLE:-virtual-v2} fallback supplies the default
+#   COMPOSE_PROJECT  docker compose project name (default: ngt) - the
+#                    GNUmakefile passes its COMPOSE_PROJECT so `make clean`
+#                    tears down the same project this script starts
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+nginx_server_proto="http"
+nginx_server_host="localhost"
+nginx_server_port="8989"
+
+test_server="${nginx_server_proto}://${nginx_server_host}:${nginx_server_port}"
+test_fail_exit_code=2
+no_dep_exit_code=3
+build_dep_exit_code=4
+
+test_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+repo_dir="$( dirname "${test_dir}" )"
+test_compose_config="${test_dir}/docker-compose.yaml"
+test_compose_project="${COMPOSE_PROJECT:-ngt}"
+
+minio_server="http://localhost:9090"
+minio_user="AKIAIOSFODNN7EXAMPLE"
+minio_passwd="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+minio_name="${test_compose_project}_minio_1"
+minio_bucket="bucket-1"
+
+DOCKER="${DOCKER:-docker}"
+NGINX_TYPE="${NGINX_TYPE:-oss}"
+UNPRIVILEGED="${UNPRIVILEGED:-0}"
+
+p() {
+  printf "\033[34;1m▶\033[0m "
+  echo "$1"
+}
+
+e() {
+  >&2 echo "$1"
+}
+
+if ! { [ "${NGINX_TYPE}" == "oss" ] || [ "${NGINX_TYPE}" == "plus" ]; }; then
+  e "Invalid NGINX type: ${NGINX_TYPE} - must be either 'oss' or 'plus'"
+  exit ${no_dep_exit_code}
+fi
+
+# Validate before the first numeric [ -eq ] comparison: a non-numeric value
+# (e.g. UNPRIVILEGED=true) would otherwise print an 'integer expression
+# expected' warning and silently select the privileged port 80 branch.
+if ! { [ "${UNPRIVILEGED}" == "0" ] || [ "${UNPRIVILEGED}" == "1" ]; }; then
+  e "Invalid UNPRIVILEGED value: ${UNPRIVILEGED} - must be 0 or 1"
+  exit ${no_dep_exit_code}
+fi
+
+# The unprivileged image rewrites 'listen 80;' to 'listen 8080;' at build
+# time (Dockerfile.unprivileged); every listen-related assertion keys off
+# this single value.
+if [ "${UNPRIVILEGED}" -eq 1 ]; then
+  gateway_listen_port=8080
+else
+  gateway_listen_port=80
+fi
+
+is_windows="0"
+if [ "${OS:-}" == "Windows_NT" ]; then
+  is_windows="1"
+elif command -v uname > /dev/null; then
+  uname_output="$(uname -s)"
+  if [[ "${uname_output}" == *"_NT-"* ]]; then
+    is_windows="1"
+  fi
+fi
+
+docker_cmd="$(command -v "${DOCKER}" || true)"
+if ! [ -x "${docker_cmd}" ]; then
+  e "required dependency not found: ${DOCKER} not found in the path or not executable"
+  exit ${no_dep_exit_code}
+fi
+
+# An array so that a docker path containing spaces (e.g. Git Bash resolving
+# to '/c/Program Files/Docker/.../docker') survives expansion intact. The
+# legacy docker-compose fallback only applies to the stock docker CLI: with a
+# DOCKER override (e.g. podman) it would silently drive the compose stack
+# with a different engine than the rest of the suite.
+if "${docker_cmd}" compose version > /dev/null 2>&1; then
+  docker_compose_cmd=("${docker_cmd}" compose)
+elif [ "${DOCKER}" == "docker" ] && command -v docker-compose > /dev/null; then
+  docker_compose_cmd=(docker-compose)
+else
+  e "required dependency not found: ${DOCKER} compose (or docker-compose) not found in the path or not executable"
+  exit ${no_dep_exit_code}
+fi
+e "Using Docker Compose command: ${docker_compose_cmd[*]}"
+
+curl_cmd="$(command -v curl || true)"
+if ! [ -x "${curl_cmd}" ]; then
+  e "required dependency not found: curl not found in the path or not executable"
+  exit ${no_dep_exit_code}
+fi
+
+if command -v mc > /dev/null; then
+  mc_cmd="$(command -v mc)"
+elif [ -x "${repo_dir}/.bin/mc" ]; then
+  mc_cmd="${repo_dir}/.bin/mc"
+else
+  e "required dependency not found: mc not found in the path or not executable"
+  exit ${no_dep_exit_code}
+fi
+e "Using MinIO Client: ${mc_cmd}"
+
+wait_for_it_cmd="$(command -v wait-for-it || true)"
+if ! [ -x "${wait_for_it_cmd}" ]; then
+  e "wait-for-it command not available, consider installing to prevent race conditions"
+fi
+
+compose() {
+  # Hint to docker-compose the internal port to map for the container
+  if [ "${UNPRIVILEGED}" -eq 1 ]; then
+    export NGINX_INTERNAL_PORT=8080
+  else
+    export NGINX_INTERNAL_PORT=80
+  fi
+
+  if [ "${NGINX_TYPE}" == "plus" ]; then
+    if [ -f /etc/nginx/license.jwt ]; then
+      NGINX_LICENSE_JWT="$(cat /etc/nginx/license.jwt)"
+    elif [ -f "${repo_dir}/license.jwt" ]; then
+      NGINX_LICENSE_JWT="$(cat "${repo_dir}/license.jwt")"
+    else
+      e "NGINX Plus license file not found: /etc/nginx/license.jwt or ${repo_dir}/license.jwt"
+      exit ${build_dep_exit_code}
+    fi
+  else
+    NGINX_LICENSE_JWT=""
+  fi
+
+  export NGINX_LICENSE_JWT
+
+  "${docker_compose_cmd[@]}" -f "${test_compose_config}" -p "${test_compose_project}" "$@"
+}
+
+integration_test_data() {
+  # Write problematic files to disk if we are not on Windows. Originally,
+  # these files were checked in, but that prevented the git repository from
+  # being cloned on Windows machines.
+  if [ "$is_windows" == "0" ]; then
+    echo "Writing weird filename: ${test_dir}/data/bucket-1/a/%@!*()=\$#^&|.txt"
+    echo 'We are but selling water next to a river.' > "${test_dir}"'/data/bucket-1/a/%@!*()=$#^&|.txt'
+  fi
+
+  p "Starting Docker Compose Environment"
+  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
+  COMPOSE_COMPATIBILITY=true compose up -d
+
+  # Hit minio's health check end point to see if it has started up
+  for (( i=1; i<=3; i++ ))
+  do
+    echo "Querying minio server to see if it is ready"
+    # `|| true` keeps errexit from aborting the retry loop when minio is not
+    # listening yet (curl exits 7 on connection refused but still prints 000).
+    minio_is_up="$(${curl_cmd} -s -o /dev/null -w '%{http_code}' "${minio_server}"/minio/health/cluster || true)"
+    if [ "${minio_is_up}" = "200" ]; then
+      break
+    else
+      sleep 2
+    fi
+  done
+
+  p "Adding test data to container"
+  "${mc_cmd}" alias set "$minio_name" "$minio_server" "$minio_user" "$minio_passwd"
+  # --ignore-existing keeps a bucket left behind by an aborted previous run
+  # (compose containers survive a failed teardown) from failing the seeding
+  # step under errexit on every subsequent run.
+  "${mc_cmd}" mb --ignore-existing "$minio_name/$minio_bucket"
+  echo "Copying contents of ${test_dir}/data/$minio_bucket to Docker container $minio_name"
+  for file in "${test_dir}/data/$minio_bucket"/*; do
+    "${mc_cmd}" cp -r "${file}" "$minio_name/$minio_bucket"
+  done
+  echo "Docker diff output:"
+  "${docker_cmd}" diff "$minio_name"
+}
+
+integration_test_listen_directives() {
+  p "Verifying rendered listen directives"
+  expected_listen_port="${gateway_listen_port}"
+  rendered_conf="$(compose exec -T nginx-s3-gateway cat /etc/nginx/conf.d/default.conf)"
+  if ! echo "${rendered_conf}" | grep -q "listen[[:space:]]*${expected_listen_port};"; then
+    e "rendered default.conf is missing the IPv4 listen directive"
+    exit "$test_fail_exit_code"
+  fi
+  # 02-ipv6-enable.sh injects the IPv6 listen directive only when the
+  # container kernel supports IPv6, so assert against the same condition.
+  if compose exec -T nginx-s3-gateway test -f /proc/net/if_inet6; then
+    if ! echo "${rendered_conf}" | grep -q "listen[[:space:]]*\[::\]:${expected_listen_port};"; then
+      e "container kernel supports IPv6 but rendered default.conf has no IPv6 listen directive"
+      exit "$test_fail_exit_code"
+    fi
+  elif echo "${rendered_conf}" | grep -q "\[::\]"; then
+    e "container kernel lacks IPv6 but rendered default.conf has an IPv6 listen directive"
+    exit "$test_fail_exit_code"
+  fi
+}
+
+integration_test() {
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite for v%s signatures\e[22m\n" "$1"
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with ALLOW_DIRECTORY_LIST=%s\e[22m\n" "$2"
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with PROVIDE_INDEX_PAGE=%s\e[22m\n" "$3"
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=%s\e[22m\n" "$4"
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with STRIP_LEADING_DIRECTORY_PATH=%s\e[22m\n" "$5"
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with PREFIX_LEADING_DIRECTORY_PATH=%s\e[22m\n" "$6"
+
+  p "Starting Docker Compose Environment"
+  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=$1 ALLOW_DIRECTORY_LIST=$2 PROVIDE_INDEX_PAGE=$3 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 STRIP_LEADING_DIRECTORY_PATH=$5 PREFIX_LEADING_DIRECTORY_PATH=$6 compose up -d
+
+  if [ -x "${wait_for_it_cmd}" ]; then
+    "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
+  fi
+
+  p "Starting HTTP API tests (v$1 signatures)"
+  echo "  test/integration/test_api.sh \"$test_server\" \"$test_dir\" $1 $2 $3 $4 $5 $6"
+  bash "${test_dir}/integration/test_api.sh" "${test_server}" "${test_dir}" "$1" "$2" "$3" "$4" "$5" "$6";
+
+  # We check to see if NGINX is in fact using the correct version of AWS
+  # signatures as it was configured to do. `|| true` because grep -c exits 1
+  # on a count of zero, which must reach the check below rather than abort
+  # the script through errexit before it can print the diagnostic.
+  sig_versions_found_count=$(compose logs nginx-s3-gateway | grep -c "AWS Signatures Version: v$1\|AWS v$1 Auth" || true)
+
+  if [ "${sig_versions_found_count}" -lt 3 ]; then
+    e "NGINX was not detected as using the correct signatures version - examine logs"
+    compose logs nginx-s3-gateway
+    exit "$test_fail_exit_code"
+  fi
+}
+
+integration_test_cache_bypass() {
+  bypass_setting=$1  # "false" or "true" - passed through compose to the gateway
+  # The assertion set follows the setting so that the two can never be passed
+  # as a mismatched pair.
+  if [ "${bypass_setting}" = "true" ]; then
+    bypass_phase="enabled"
+  else
+    bypass_phase="disabled"
+  fi
+
+  printf "\033[34;1m▶\033[0m"
+  printf "\e[1m Integration test suite with PROXY_CACHE_BYPASS_NO_CACHE=%s\e[22m\n" "${bypass_setting}"
+
+  p "Starting Docker Compose Environment"
+  # The six standard configuration values are pinned to a known baseline
+  # (the v4 signatures, no-listing configuration) so that URL rewriting
+  # configured by the STRIP/PREFIX_LEADING_DIRECTORY_PATH passes cannot leak
+  # in. Changing the environment makes compose recreate the gateway
+  # container, which discards the proxy cache so that each phase starts with
+  # an empty cache.
+  # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" PROXY_CACHE_BYPASS_NO_CACHE="${bypass_setting}" compose up -d
+
+  if [ -x "${wait_for_it_cmd}" ]; then
+    "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
+  fi
+
+  p "Starting cache bypass tests (phase: ${bypass_phase})"
+  echo "  test/integration/test_cache_bypass.sh \"$test_server\" \"$test_dir\" ${bypass_phase} \"${mc_cmd}\" \"${minio_name}\" \"${minio_bucket}\""
+  bash "${test_dir}/integration/test_cache_bypass.sh" "${test_server}" "${test_dir}" "${bypass_phase}" "${mc_cmd}" "${minio_name}" "${minio_bucket}"
+}
+
+finish() {
+  result=$?
+  # Disarm the traps first: a test failure otherwise runs finish twice (ERR,
+  # then again when its `exit` fires the EXIT trap), double-dumping logs and
+  # re-running the teardown. Cleanup steps are best-effort (`|| true`) so a
+  # failing step - e.g. removing an mc alias that was never registered
+  # because the run aborted before integration_test_data - cannot trip
+  # errexit inside the trap and replace the preserved test exit code.
+  trap - EXIT ERR SIGTERM SIGINT
+
+  if [ $result -ne 0 ]; then
+    e "Error running tests - outputting container logs"
+    compose logs || true
+  fi
+
+  p "Cleaning up Docker compose environment"
+  compose stop || true
+  compose rm -f -v || true
+  "${mc_cmd}" alias rm "$minio_name" || true
+
+  exit ${result}
+}
+trap finish EXIT ERR SIGTERM SIGINT
+
+### ENTRYPOINT SCRIPT TESTS
+# These only need the image and a docker CLI, so they run before the compose
+# environment comes up.
+
+p "Testing IPv6 entrypoint script"
+bash "${test_dir}/integration/test_entrypoint_ipv6.sh" "${docker_cmd}" "${gateway_listen_port}"
+
+p "Testing settings output entrypoint script"
+bash "${test_dir}/integration/test_entrypoint_output_settings.sh" "${docker_cmd}"
+
+### INTEGRATION TESTS
+# The arguments correspond to gateway configuration values, e.g.
+# integration_test 2 0 0 0 "" ""
+# AWS_SIGS_VERSION=$1 : any valid AWS Sigs version. Supported values are `2` or `4`
+# ALLOW_DIRECTORY_LIST=$2 : boolean value denoted by `0` or `1`
+# PROVIDE_INDEX_PAGE=$3 : boolean value denoted by `0` or `1`
+# APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 : boolean value denoted by `0` or `1`
+# STRIP_LEADING_DIRECTORY_PATH=$5 : prefix to strip from request paths, or ""
+# PREFIX_LEADING_DIRECTORY_PATH=$6 : prefix prepended to S3 keys, or ""
+# All six are required (the script runs under `set -o nounset`).
+#
+# These are various invocations of ./test/integration/test_api.sh
+# where the flags represent different configurations for that single test
+# file.
+
+integration_test_data
+
+p "Testing API with AWS Signature V2 and allow directory listing off"
+integration_test 2 0 0 0 "" ""
+
+integration_test_listen_directives
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing API with AWS Signature V2 and allow directory listing on"
+integration_test 2 1 0 0 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing API with AWS Signature V2 and static site on"
+integration_test 2 0 1 0 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing API with AWS Signature V2 and allow directory listing on and append slash and allow index"
+integration_test 2 1 1 1 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Test API with AWS Signature V4 and allow directory listing off"
+integration_test 4 0 0 0 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Test API with AWS Signature V4 and allow directory listing on and appending /"
+integration_test 4 1 0 1 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Test API with AWS Signature V4 and static site on appending /"
+integration_test 4 0 1 1 "" ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing API with AWS Signature V2 and allow directory listing off and prefix stripping on"
+integration_test 2 0 0 0 /my-bucket ""
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Test API with AWS Signature V4 and prefix leading directory path on"
+integration_test 4 0 0 0 "" "/b"
+
+p "Test API with AWS Signature V4 and prefix leading directory path on and prefix stripping on"
+integration_test 4 0 0 0 "/tostrip" "/b"
+
+p "Testing API with AWS Signature V2 and prefix leading directory path"
+integration_test 2 0 0 0 "" "/b"
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing proxy cache bypass with PROXY_CACHE_BYPASS_NO_CACHE=false (default)"
+integration_test_cache_bypass "false"
+
+compose stop nginx-s3-gateway # Restart with new config
+
+p "Testing proxy cache bypass with PROXY_CACHE_BYPASS_NO_CACHE=true"
+integration_test_cache_bypass "true"
+
+p "All integration tests complete"

--- a/test/run_unit_tests.sh
+++ b/test/run_unit_tests.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright 2026 F5, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Runs the njs unit test suites inside the already-built gateway image.
+# Invoked by the GNUmakefile (make test-unit / make retest) - not intended
+# to be run directly, although doing so is harmless.
+#
+# Every test/unit/*_test.js file is discovered by glob and runs twice: once
+# without AWS_SESSION_TOKEN and once with it, because credential handling
+# branches on token presence. New test files are picked up automatically.
+#
+# Environment:
+#   DOCKER      docker CLI to use (default: docker)
+#   IMAGE_NAME  gateway image tag to test (default: nginx-s3-gateway)
+#   NJS_LATEST  1 when testing the latest-njs variant image (default: 0)
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+DOCKER="${DOCKER:-docker}"
+IMAGE_NAME="${IMAGE_NAME:-nginx-s3-gateway}"
+NJS_LATEST="${NJS_LATEST:-0}"
+
+# Validate before the numeric [ -eq ] comparison below: a non-numeric value
+# (e.g. NJS_LATEST=true) would otherwise print an 'integer expression
+# expected' warning and silently select the stable-njs `-t module` flag,
+# which the latest-njs image's CLI does not understand.
+if ! { [ "${NJS_LATEST}" = "0" ] || [ "${NJS_LATEST}" = "1" ]; }; then
+  >&2 echo "Invalid NJS_LATEST value: ${NJS_LATEST} - must be 0 or 1"
+  exit 2
+fi
+
+p() {
+  printf "\033[34;1m▶\033[0m "
+  echo "$1"
+}
+
+# The njs CLI is transitioning from `-t module` to `-m`; the latest-njs
+# variant image ships a CLI that only understands the new flag.
+if [ "${NJS_LATEST}" -eq 1 ]; then
+  njs_module_flags=(-m)
+else
+  njs_module_flags=(-t module)
+fi
+
+# Environment the modules read at import time. Values here must be present
+# before the module loads because they are captured into module-level
+# constants - mutating process.env inside a test cannot change them.
+unit_test_env=(
+  -e "DEBUG=true"
+  -e "S3_STYLE=virtual-v2"
+  -e "S3_SERVICE=s3"
+  -e "AWS_ACCESS_KEY_ID=unit_test"
+  -e "AWS_SECRET_ACCESS_KEY=unit_test"
+  -e "S3_BUCKET_NAME=unit_test"
+  -e "S3_SERVER=unit_test"
+  -e "S3_SERVER_PROTO=https"
+  -e "S3_SERVER_PORT=443"
+  -e "S3_REGION=test-1"
+  -e "AWS_SIGS_VERSION=4"
+  -e "APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true"
+)
+
+# Additional arguments (extra -e flags) may follow the test file name.
+run_unit_test() {
+  test_file="$1"
+  shift
+  # MSYS_NO_PATHCONV=1 stops Git Bash on Windows from rewriting the
+  # container-side paths: https://github.com/docker/for-win/issues/6754
+  MSYS_NO_PATHCONV=1 "${DOCKER}" run     \
+    --rm                                 \
+    -v "${script_dir}/unit:/var/tmp"     \
+    --workdir /var/tmp                   \
+    "${unit_test_env[@]}"                \
+    "$@"                                 \
+    --entrypoint /usr/bin/njs            \
+    "${IMAGE_NAME}" "${njs_module_flags[@]}" -p '/etc/nginx' "/var/tmp/${test_file}"
+}
+
+for test_path in "${script_dir}"/unit/*_test.js; do
+  test_file="$(basename "${test_path}")"
+  p "Running unit tests in ${test_file} without a session token"
+  run_unit_test "${test_file}"
+  p "Running unit tests in ${test_file} with a session token"
+  run_unit_test "${test_file}" -e "AWS_SESSION_TOKEN=unit_test"
+done
+
+p "All unit tests complete"

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -289,13 +289,13 @@ function testTrailslashControl() {
 
     // trailslashControl reads APPEND_SLASH_FOR_POSSIBLE_DIRECTORY into a
     // module-level const at import time, so the flag must be present in the
-    // unit test runner environment (test.sh sets it in all four docker-run
-    // blocks). Fail fast with a setup error rather than a misleading
-    // assertion failure when it is missing.
+    // unit test runner environment (the unit_test_env list in
+    // test/run_unit_tests.sh sets it). Fail fast with a setup error rather
+    // than a misleading assertion failure when it is missing.
     if (process.env['APPEND_SLASH_FOR_POSSIBLE_DIRECTORY'] !== 'true') {
         throw 'testTrailslashControl requires ' +
             'APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true in the unit test ' +
-            'runner environment (see test.sh)';
+            'runner environment (see test/run_unit_tests.sh)';
     }
 
     const testCases = [


### PR DESCRIPTION
## Summary

Completes the migration to the GNUmakefile as the sole build/test interface. `test.sh` is deprecated and CI now runs everything through make.

### Test logic extracted into two make-native runners

- **`test/run_unit_tests.sh`** — globs `test/unit/*_test.js`, so new unit test files need **no wiring** (previously each file had to be added to test.sh by hand). Every suite runs both with and without `AWS_SESSION_TOKEN`, and the env list lives in a single `unit_test_env` array instead of four duplicated docker-run blocks. `NJS_LATEST=1` selects the latest-njs CLI's `-m` flag.
- **`test/run_integration_tests.sh`** — the compose orchestration, MinIO data seeding, entrypoint-script tests, the full API/cache-bypass matrix, and the cleanup trap. `UNPRIVILEGED=1` drives the port-8080 assertions.

### test.sh becomes a deprecated wrapper

It warns and `exec`s the equivalent make target, keeping the old flag interface (`--type`, `--latest-njs`, `--unprivileged`, `CI=true` → no-rebuild retest). The one dropped behavior is stacking both variant flags at once, which CI never used; the wrapper errors with guidance instead.

### Makefile

- `retest` / `retest-latest-njs` / `retest-unprivileged` invoke the runners directly; new `test-unit` / `test-integration` targets run each half independently.
- New `NONVARIANT_GUARD` (inverse of the existing `VARIANT_GUARD`) keeps non-variant targets from silently driving a variant floating image.
- `check-tools` is now a prerequisite of the retest targets, restoring test.sh's fail-fast dependency checks.
- `SC2120` burned off the shellcheck exclude list; `DOCKER=` now genuinely reaches the test flows; `COMPOSE_PROJECT` passes through so `make clean` and the suite share one project name.

### CI

- The three `./test.sh` steps become `make retest`, `make retest-latest-njs`, and `make retest-unprivileged`.
- The workflow-level `env: CI: true` block is removed (it existed only to make test.sh skip its internal build).
- New parallel **lint job** runs `make lint` with checkmake pinned at v0.3.2 (shellcheck is preinstalled on the runners).

### Latent bugs fixed by the strict runners

The new scripts run under `errexit`/`nounset`/`pipefail`, which surfaced and fixed several issues the old script's looser handling masked: the cleanup trap no longer double-fires or clobbers the real test exit code; the MinIO health poll survives connection-refused during startup; a zero `grep -c` signature count no longer aborts before its diagnostic prints; `mc mb --ignore-existing` prevents a self-perpetuating failure loop after an aborted teardown; the compose command is an array (space-safe docker paths on Git Bash); and non-0/1 variant knob values are rejected with a clear error.

## Verification

- `make lint` passes with checkmake v0.3.2 (the CI pin) and shellcheck 0.8.0, 0.9.0, and 0.10.0.
- Full `make test` (build + unit + complete integration matrix): green.
- Full `make test-unprivileged` (variant guard + 8080 assertions): green.
- `NJS_LATEST=1` unit path (`-m` flag): green.
- Both guards exercised live; test.sh wrapper flag→target mapping validated for all combinations.
- Final full `make retest` after review fixes: green.

The only path not runnable locally was the `Dockerfile.latest-njs` image build (VPN TLS interception of github.com inside build containers on the dev machine — pre-existing and environment-only); CI runners build it normally.