### PR TITLE
ci: run the three test tracks concurrently and drop the apt-get step

### DIFF
--- a/.github/actions/install-mc/action.yml
+++ b/.github/actions/install-mc/action.yml
@@ -1,0 +1,31 @@
+---
+name: Install MinIO Client
+description: >
+  Installs the pinned MinIO client (mc) into ./.bin, where the GNUmakefile's
+  check-tools target and test/run_integration_tests.sh both look for it.
+inputs:
+  release:
+    description: >
+      mc release artifact to install. Must be the full artifact name, because
+      the published .sha256sum file references the binary by that name and
+      `sha256sum --check` matches on it.
+    required: false
+    default: mc.RELEASE.2023-06-19T19-31-19Z
+runs:
+  using: composite
+  steps:
+    # Downloaded rather than cached: the release is ~25 MB and arrives from
+    # MinIO's CDN in about a second, which is no slower than an actions/cache
+    # round trip and cannot serve a stale binary.
+    - name: Install MinIO Client
+      shell: bash
+      env:
+        MC_RELEASE: ${{ inputs.release }}
+      run: |
+        mkdir -p .bin
+        cd .bin
+        base_url="https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive"
+        curl --retry 6 --fail --location --output "${MC_RELEASE}" "${base_url}/${MC_RELEASE}"
+        curl --retry 6 --fail --silent --location "${base_url}/${MC_RELEASE}.sha256sum" | sha256sum --check -
+        mv "${MC_RELEASE}" mc
+        chmod +x mc

--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -13,304 +13,128 @@ on:
   workflow_dispatch:
 permissions: read-all
 
-# Job progression.  We make sure that the base image [oss] builds and passes tests before kicking off the other builds
-#                                ┌──────────────────┐        ┌────────────────┐      ┌────────────────┐
-# ┌─────────┐     ┌─────────┬────► Build Latest NJS ├────────►Test Latest NJS ├─────►│Push Latest NJS │
-# │Build OSS├────►│Test OSS │    └──────────────────┘        └────────────────┘      └────────────────┘
-# └─────────┘     └──┬──────┤
-#                    │      │    ┌──────────────────┐       ┌──────────────────┐     ┌─────────────────┐
-#                    │      └────►Build Unprivileged├───────►Test Unprivileged ├────►│Push Unprivileged│
-#                    │           └──────────────────┘       └──────────────────┘     ├────────┬────────┘
-#                    │                                                               ├────────┤
-#                    └──────────────────────────────────────────────────────────────►│Push OSS│
-#                                                                                    └────────┘
-# As a last step (only if run from main) multi-architecture images are built and pushed to Docker Hub and the GitHub Container Registry
+# Supersede a PR's in-flight run when it is pushed to again. Deliberately
+# scoped to pull_request only: for main, the merge queue, and the weekly
+# schedule the group key is the ref (unique per queued PR), and those runs
+# either publish images or gate a merge, so they must always finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Job graph. Every test job builds the image it tests, so the three test
+# tracks are fully independent and run concurrently:
+#
+#   ┌──────┐
+#   │ Lint │
+#   └──────┘
+#   ┌────────────────────────────────────────┐
+#   │ Test OSS  (matrix: virtual, virtual-v2)├──┐
+#   └────────────────────────────────────────┘  │
+#   ┌────────────────────────────────────────┐  │  ┌──────────────────────────┐
+#   │ Test OSS + latest njs                  ├──┼─►│ Tag and push (main only) │
+#   └────────────────────────────────────────┘  │  └──────────────────────────┘
+#   ┌────────────────────────────────────────┐  │
+#   │ Test OSS unprivileged                  ├──┘
+#   └────────────────────────────────────────┘
+#
+# This replaces a previous six-job pipeline that built the OSS base once,
+# shipped it between jobs as an uploaded tar, and gated the two variant
+# builds on the OSS tests passing. Both mechanisms cost more than they saved:
+# the OSS image builds in ~10s, which is less than the upload + download +
+# `docker load` round trip it replaced, and the test-OSS gate serialized
+# ~100s onto the critical path of every PR to conserve runner minutes that
+# are free on a public repository.
+#
+# Each job's single test step is a `make` target -- the same entry point
+# `make ci` uses locally -- so a green CI run and a green local run exercise
+# the same code path rather than two similar ones that can drift.
 
 jobs:
   lint:
     name: Lint (checkmake + shellcheck)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      CHECKMAKE_VERSION: v0.3.2
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # shellcheck is preinstalled on the GitHub runners; checkmake is not.
+      # Cached because `go install` compiles it from source, which is most of
+      # this job's runtime.
+      - name: Restore cached checkmake
+        id: cache-checkmake
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/go/bin/checkmake
+          key: ${{ runner.os }}-checkmake-${{ env.CHECKMAKE_VERSION }}
+
       - name: Install checkmake
-        run: |
-          go install github.com/checkmake/checkmake/cmd/checkmake@v0.3.2
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+        if: steps.cache-checkmake.outputs.cache-hit != 'true'
+        run: go install github.com/checkmake/checkmake/cmd/checkmake@${{ env.CHECKMAKE_VERSION }}
+
+      # Separate step because GITHUB_PATH only affects later steps, and this
+      # has to apply whether checkmake was restored or freshly installed.
+      - name: Add the Go bin directory to PATH
+        run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
 
       - name: Lint
         run: make lint
 
-  build-oss-for-test:
-    name: Build NGINX OSS image
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    steps:
-      - name: Check out the codebase
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-
-      - name: Build and export
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          file: Dockerfile.oss
-          context: .
-          tags: nginx-s3-gateway , nginx-s3-gateway:oss
-          outputs: type=docker,dest=${{ runner.temp }}/oss.tar
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: oss
-          path: ${{ runner.temp }}/oss.tar
-          retention-days: 1
-          if-no-files-found: error
-
   test-oss:
     name: Test NGINX OSS image
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-oss-for-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     strategy:
+      # Report both addressing styles instead of cancelling the second one as
+      # soon as the first fails; they exercise different signing paths and the
+      # legs run concurrently, so nothing is saved by stopping early.
+      fail-fast: false
       matrix:
         path_style: [virtual, virtual-v2]
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install dependencies
-        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
-        # step until the job timeout and knocks PRs out of the merge queue.
-        timeout-minutes: 5
-        run: |
-          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
-          sudo apt-get $APT_OPTS update -qq
-          sudo apt-get $APT_OPTS install -y curl wait-for-it
-
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-
       - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
+        uses: ./.github/actions/install-mc
 
-      - name: Download artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: oss
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/oss.tar
-
-      - name: Run tests - stable njs version
-        run: make retest NGINX_TYPE=oss S3_STYLE=${{ matrix.path_style }}
-
-  build-latest-njs-for-test:
-    name: Build NGINX OSS image using latest njs commit
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: test-oss
-    steps:
-      - name: Check out the codebase
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          driver: docker
-
-      - name: Download artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: oss
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/oss.tar
-
-      - name: Build and load oss image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          file: Dockerfile.latest-njs
-          context: .
-          tags: nginx-s3-gateway:latest-njs-oss
-          load: true
-
-      # Save manually here since we need to use `docker` buildx but that can't output a file that upload-artifact likes.
-      - name: Export image to a tar
-        run: |
-          docker save nginx-s3-gateway:latest-njs-oss > ${{ runner.temp }}/latest-njs.tar
-
-      - name: Upload artifact - latest-njs
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: latest-njs
-          path: ${{ runner.temp }}/latest-njs.tar
-          retention-days: 1
-          if-no-files-found: error
+      - name: Build and test - stable njs version
+        run: make test NGINX_TYPE=oss S3_STYLE=${{ matrix.path_style }}
 
   test-latest-njs:
     name: Test NGINX OSS image using latest njs commit
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-latest-njs-for-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Install dependencies
-        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
-        # step until the job timeout and knocks PRs out of the merge queue.
-        timeout-minutes: 5
-        run: |
-          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
-          sudo apt-get $APT_OPTS update -qq
-          sudo apt-get $APT_OPTS install -y curl wait-for-it
-
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
 
       - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
+        uses: ./.github/actions/install-mc
 
-      - name: Download artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: latest-njs
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/latest-njs.tar
-          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
-
-      - name: Run tests - latest njs version
-        run: make retest-latest-njs NGINX_TYPE=oss
-
-  build-unprivileged-for-test:
-    name: Build NGINX OSS unprivileged image
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: test-oss
-    steps:
-      - name: Check out the codebase
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          driver: docker
-
-      - name: Download artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: oss
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/oss.tar
-
-      - name: Build and load oss image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
-        with:
-          file: Dockerfile.unprivileged
-          context: .
-          tags: nginx-s3-gateway:unprivileged-oss
-          load: true
-
-      # Save manually here since we need to use `docker` buildx but that can't output a file that upload-artifact likes.
-      - name: Export image to a tar
-        run: |
-          docker save nginx-s3-gateway:unprivileged-oss > ${{ runner.temp }}/unprivileged.tar
-
-      - name: Upload artifact - unprivileged
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: unprivileged
-          path: ${{ runner.temp }}/unprivileged.tar
-          retention-days: 1
-          if-no-files-found: error
+      - name: Build and test - latest njs version
+        run: make test-latest-njs NGINX_TYPE=oss
 
   test-unprivileged:
     name: Test NGINX OSS unprivileged image
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    needs: build-unprivileged-for-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install dependencies
-        # Network timeouts + retries: a wedged apt mirror otherwise hangs this
-        # step until the job timeout and knocks PRs out of the merge queue.
-        timeout-minutes: 5
-        run: |
-          APT_OPTS="-o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 -o Acquire::Retries=3"
-          sudo apt-get $APT_OPTS update -qq
-          sudo apt-get $APT_OPTS install -y curl wait-for-it
-
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-
       - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
+        uses: ./.github/actions/install-mc
 
-      - name: Download artifact
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
-        with:
-          name: unprivileged
-          path: ${{ runner.temp }}
-
-      - name: Load image
-        run: |
-          docker load --input ${{ runner.temp }}/unprivileged.tar
-          docker tag nginx-s3-gateway:unprivileged-oss nginx-s3-gateway
-
-      - name: Run tests - unprivileged
-        run: make retest-unprivileged NGINX_TYPE=oss
+      - name: Build and test - unprivileged
+        run: make test-unprivileged NGINX_TYPE=oss
 
 # As a last step (only if run from main) multi-architecture images are built and pushed to Docker Hub and the GitHub Container Registry
   tag-and-push:
     name: Tag and push all built and tested NGINX images
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     needs: [test-oss, test-latest-njs, test-unprivileged]
     if: |

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -98,7 +98,7 @@ check-tools: ## Verify required build and test tooling is present
 	for tool in npx checkmake shellcheck; do \
 		command -v "$$tool" > /dev/null 2>&1 || echo "missing (optional, needed for lint/docs): $$tool"; \
 	done; \
-	for tool in wait-for-it hadolint jq; do \
+	for tool in hadolint jq; do \
 		command -v "$$tool" > /dev/null 2>&1 || echo "missing (optional): $$tool"; \
 	done; \
 	if [ "$$ok" -eq 1 ]; then echo "All required tools are present"; else exit 3; fi

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -145,10 +145,40 @@ else
 fi
 e "Using MinIO Client: ${mc_cmd}"
 
-wait_for_it_cmd="$(command -v wait-for-it || true)"
-if ! [ -x "${wait_for_it_cmd}" ]; then
-  e "wait-for-it command not available, consider installing to prevent race conditions"
-fi
+# Blocks until the gateway answers an HTTP request, replacing the external
+# wait-for-it dependency.
+#
+# Two problems with the previous arrangement. wait-for-it was an optional
+# tool, so on a host that lacked it these waits silently became no-ops. And
+# even where it was installed it only proved the *published* port was open:
+# docker binds the host side of a port mapping as soon as the container
+# starts, so a TCP connect succeeds while nginx inside is still booting. The
+# downstream suites each carry their own 2s/4s/6s backoff loop to absorb that
+# gap, and it fired on nearly every configuration change - 13 times in a
+# representative CI run, all of it pure sleep.
+#
+# Polling the same HEAD request those suites use closes the gap for real:
+# curl reports 000 until nginx accepts and answers, so this returns only once
+# a request would actually succeed, and the downstream backoffs stop firing.
+#
+# Exits non-zero on timeout so callers abort under errexit rather than
+# proceeding against a gateway that never came up.
+gateway_wait_timeout=15
+wait_for_gateway() {
+  poll_limit=$((gateway_wait_timeout * 5))
+  for (( poll=0; poll<poll_limit; poll++ )); do
+    # `|| true` because curl exits non-zero (while still printing 000) until
+    # the gateway answers, which errexit would otherwise treat as fatal.
+    gateway_status="$("${curl_cmd}" -s -o /dev/null -w '%{http_code}' \
+      --head --max-time 2 "${test_server}" || true)"
+    if [ "${gateway_status}" != "000" ]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  e "timed out after ${gateway_wait_timeout}s waiting for the gateway at ${test_server}"
+  return 1
+}
 
 compose() {
   # Hint to docker-compose the internal port to map for the container
@@ -256,9 +286,7 @@ integration_test() {
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
   COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=$1 ALLOW_DIRECTORY_LIST=$2 PROVIDE_INDEX_PAGE=$3 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 STRIP_LEADING_DIRECTORY_PATH=$5 PREFIX_LEADING_DIRECTORY_PATH=$6 compose up -d
 
-  if [ -x "${wait_for_it_cmd}" ]; then
-    "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
-  fi
+  wait_for_gateway
 
   p "Starting HTTP API tests (v$1 signatures)"
   echo "  test/integration/test_api.sh \"$test_server\" \"$test_dir\" $1 $2 $3 $4 $5 $6"
@@ -300,9 +328,7 @@ integration_test_cache_bypass() {
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
   COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" PROXY_CACHE_BYPASS_NO_CACHE="${bypass_setting}" compose up -d
 
-  if [ -x "${wait_for_it_cmd}" ]; then
-    "${wait_for_it_cmd}" -h "${nginx_server_host}" -p "${nginx_server_port}"
-  fi
+  wait_for_gateway
 
   p "Starting cache bypass tests (phase: ${bypass_phase})"
   echo "  test/integration/test_cache_bypass.sh \"$test_server\" \"$test_dir\" ${bypass_phase} \"${mc_cmd}\" \"${minio_name}\" \"${minio_bucket}\""


### PR DESCRIPTION
Measured against run [32496791234](https://github.com/nginx/nginx-s3-gateway/actions/runs/32496791234), the PR critical path was a four-job serial chain totalling **5m01s**:

| Stage | Wall | Actual work |
|---|---|---|
| `build-oss-for-test` | 30s | 9s build |
| `test-oss` (matrix ×2) | 98s | 64s tests |
| `build-latest-njs` | 59s | 35s build |
| `test-latest-njs` | 106s | 75s tests |

Two mechanisms accounted for most of it and neither paid for itself.

**Artifact hand-off.** The OSS base was built once and shipped to its four consumers as an uploaded tar. That base builds in ~10s, while the upload + job spin-up + checkout + download + `docker load` round trip it fed costs 15–25s per boundary. Building the image in the job that tests it is strictly cheaper, so the three dedicated build jobs, the artifact plumbing, and four `setup-buildx-action` invocations are gone.

**Serialization.** The two variant builds declared `needs: test-oss`, putting ~100s of OSS testing ahead of them to avoid spending runner minutes on a variant whose base was already broken. Those minutes are free on a public repo. The three test tracks are now independent.

Each track is now a single `make` target, so CI and `make ci` drive the same code path rather than two similar ones that can drift.

## Also here

- **Deleted the `apt-get install curl wait-for-it` step.** curl is preinstalled and was only being patch-upgraded (`2 upgraded, 1 newly installed`); wait-for-it supplied one bash script. It cost 13–19s in each of four jobs and was the only apt-get call in them — the failure mode the retry options above it were added to contain.
- **Replaced wait-for-it with `wait_for_gateway`, which polls over HTTP.** wait-for-it was *optional*, so where absent the readiness wait silently became a no-op; where present it only proved docker had bound the published port, not that nginx was answering. The downstream suites absorbed the gap with a 2s/4s/6s backoff that fired **13 times per run**. It now fires **zero** times.
- **Dropped the `actions/cache/restore` of `.bin`.** No save step was ever added, so it logged `Cache not found for input keys: Linux-binaries` on every run since introduction. Moved the mc install to a local composite action so the three copies cannot drift, and dropped `--insecure` from a download that is sha256-verified anyway.
- **Added a concurrency group** so pushing to a PR supersedes its in-flight run. Scoped to `pull_request`; main, merge_group and schedule runs publish images or gate merges and must always finish.
- **Cached checkmake** in the lint job, where `go install` was 17s of 25s.
- **Moved the four remaining `ubuntu-22.04` jobs to `ubuntu-24.04`.**

## Expected

| | Before | After |
|---|---|---|
| PR critical path | 5m01s | ~2m10s |

## Required status checks

⚠️ This deletes three jobs whose names were required status checks. Ruleset `6399203` has already been updated to drop `Build NGINX OSS image`, `Build NGINX OSS image using latest njs commit`, and `Build NGINX OSS unprivileged image`. The four `Test ...` check names are unchanged by this PR, so the queue keeps gating on them.

## Verification

`make test` (both `S3_STYLE` legs) and `make test-unprivileged` pass locally with zero backoff retries. `make test-latest-njs` builds through the `FROM nginx-s3-gateway` local-tag resolution that replaces the buildx `driver: docker` setup — the mechanism most worth checking — then fails in my environment only because corporate TLS interception breaks curl inside the build container. `actionlint` is clean.