### PR TITLE
fix: exit with a clear error when the test gateway is unreachable

### DIFF
--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -55,10 +55,12 @@ e() {
 
 if [ -z "${test_server}" ]; then
   e "missing first parameter: test server location (eg http://localhost:80)"
+  exit ${no_dep_exit_code}
 fi
 
 if [ -z "${test_dir}" ]; then
   e "missing second parameter: path to test data directory"
+  exit ${no_dep_exit_code}
 fi
 
 curl_cmd="$(command -v curl || true)"
@@ -203,6 +205,26 @@ for (( i=1; i<=3; i++ )); do
   sleep ${wait_time}
 done
 set -o errexit
+
+# The retry loop's last probe is six seconds stale once the final backoff
+# sleep finishes, so probe once more before giving up: under the old
+# fall-through the first assertion's curl was, in effect, that final probe,
+# and a slow-starting gateway that became ready during the last sleep must
+# keep passing. An empty response means curl exited without probing (usage
+# error or killed by a signal), so re-probe for that case as well.
+if [ "${response}" = "000" ] || [ -z "${response}" ]; then
+  response="$(${curl_cmd} -s -o /dev/null -w '%{http_code}' --head "${test_server}" || true)"
+fi
+
+# Without this guard an unreachable server kills the script via errexit at
+# the first assertion's curl - a bare curl exit code blamed on whichever
+# assertion happened to run first - instead of one clear diagnostic and the
+# documented exit code. Mirrors the guard in test_cache_bypass.sh; keep the
+# two in sync.
+if [ "${response}" = "000" ] || [ -z "${response}" ]; then
+  e "unable to reach the test server at [${test_server}] - is the gateway running?"
+  exit ${no_dep_exit_code}
+fi
 
 if [ -n "${prefix_leading_directory_path}" ]; then
   assertHttpRequestEquals "GET" "/c/d.txt" "data/bucket-1/b/c/d.txt"

--- a/test/integration/test_cache_bypass.sh
+++ b/test/integration/test_cache_bypass.sh
@@ -197,7 +197,21 @@ for (( i=1; i<=3; i++ )); do
 done
 set -o errexit
 
-if [ "${response}" = "000" ]; then
+# The retry loop's last probe is six seconds stale once the final backoff
+# sleep finishes, so probe once more before giving up: a slow-starting
+# gateway that became ready during the last sleep must not be reported as
+# down. An empty response means curl exited without probing (usage error or
+# killed by a signal), so re-probe for that case as well.
+if [ "${response}" = "000" ] || [ -z "${response}" ]; then
+  response="$(${curl_cmd} -s -o /dev/null -w '%{http_code}' --head "${test_server}" || true)"
+fi
+
+# Without this guard an unreachable server kills the script via errexit at
+# the first assertion's curl - a bare curl exit code blamed on whichever
+# assertion happened to run first - instead of one clear diagnostic and the
+# documented exit code. Mirrors the guard in test_api.sh; keep the two in
+# sync.
+if [ "${response}" = "000" ] || [ -z "${response}" ]; then
   e "unable to reach the test server at [${test_server}] - is the gateway running?"
   exit ${no_dep_exit_code}
 fi


### PR DESCRIPTION
Found while investigating whether the integration suite's readiness wait is still needed, then hardened by a deep review pass.

`test_api.sh` probes the gateway up to three times before starting, but never checks the result. When the retry loop is exhausted it falls straight through into the assertions with `response` still `000`, and `errexit` kills the script at the first assertion's curl — a bare curl exit code (`7`), blamed on whichever object happened to be tested first, instead of one clear diagnostic and the script's own documented `no_dep_exit_code` (`3`), which is what its sibling `test_cache_bypass.sh` already reports.

Guarding that fall-through correctly turned out to need three pieces, now shared by both suites:

1. **Re-probe once before condemning the run.** The retry loop sleeps 6s after its *final* failed probe, so the value a bare guard would read is six seconds stale — and under the old fall-through, the first assertion's curl was in effect a fresh final probe. A slow-starting gateway that becomes ready during that last sleep must keep passing. This also fixes the same latent flake in `test_cache_bypass.sh`'s pre-existing guard (#552), which could fail a run against a gateway that was up by the time it exited.
2. **Treat an empty response like `000`.** curl emits no `%{http_code}` writeout on usage errors or when killed by a signal, so an empty string previously broke out of the retry loop as "server up" and would sail past a bare `000` check, failing later with an opaque `Expected [200] Actual []`.
3. **Exit on the missing-argument checks.** `test_api.sh` printed the missing-parameter errors and carried on; an empty server URL then burned the full 12s retry loop before dying with a misleading "unreachable" message. `test_cache_bypass.sh` already exited; now both do.

## Scope

Pre-existing, and independent of #561 — different files, no conflict. #561's HTTP readiness poll makes the fall-through unlikely via `make`, but the scripts are standalone-capable and the poll is not a guarantee, so the guard earns its place either way.

## Verification

- Closed port (9/discard): both scripts exit `3` with one clear message — previously `test_api.sh` exited `7` with `curl: (7) Failed to connect...` attributed to object `a.txt`.
- Server becoming ready 8s after start (inside the final backoff sleep): passes the guard and reaches the assertions — a bare guard without the re-probe wrongly failed this case.
- Empty first argument: exits `3` immediately with the missing-parameter message.
- `make lint` passes; full `make test` passes with the guard never firing.