### PR TITLE
build: lint and format Markdown with rumdl

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 ### Proposed changes
 
-Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR description (not in the title of the PR).
+Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a
+link to that issue using one of the
+[supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
+in this PR description (not in the title of the PR).
 
 ### Checklist
 

--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -51,11 +51,12 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint (checkmake + shellcheck)
+    name: Lint (checkmake + shellcheck + rumdl)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     env:
       CHECKMAKE_VERSION: v0.3.2
+      RUMDL_VERSION: 0.2.58
     steps:
       - name: Check out the codebase
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -78,6 +79,12 @@ jobs:
       # has to apply whether checkmake was restored or freshly installed.
       - name: Add the Go bin directory to PATH
         run: echo "$HOME/go/bin" >> "$GITHUB_PATH"
+
+      # rumdl is also not preinstalled. Installed from npm (which ships the
+      # prebuilt binary, so there is nothing to compile and nothing to cache)
+      # and pinned so a new release cannot fail this job on unchanged docs.
+      - name: Install rumdl
+        run: npm install --global "rumdl@${RUMDL_VERSION}"
 
       - name: Lint
         run: make lint

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,34 @@
+# rumdl configuration -- https://rumdl.dev
+#
+# Markdown lint/format rules for this repo's prose docs. Run via `make lint-md`
+# (report) and `make fmt-md` (apply fixes).
+
+[global]
+# .opencode/ holds the local rule digests (kept verbatim, mirrored to .claude
+# via symlink); node_modules is dependency noise.
+exclude = [".opencode", ".claude", "node_modules"]
+
+# GitHub issue/PR templates conventionally open with a task-oriented heading
+# (e.g. "### Proposed changes"), not a document-level H1 -- MD041 doesn't fit.
+disable = ["MD041"]
+
+# House style: prose wraps at 120 columns. Deliberately-formatted code
+# examples and tables routinely run past that and must not be reflowed, so
+# MD013 skips them.
+[MD013]
+line-length = 120
+code-blocks = false
+tables = false
+
+# Align table columns in source so the pipes line up in raw form and in diffs.
+[MD060]
+enabled = true
+style = "aligned"
+
+# House style: dash bullets (`-`), matching the majority of existing docs.
+[MD004]
+style = "dash"
+
+# <br> is the only way to force a line break inside a table cell.
+[MD033]
+allowed-elements = ["br"]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI coding agents working in this repository.
 
 NGINX S3 Gateway configures NGINX (OSS or Plus) as an authenticating, caching
 proxy in front of S3-compatible object stores. There is no application server:
-the "code" is NGINX configuration plus njs (NGINX JavaScript) modules, packaged
+the "code" is NGINX configuration plus [njs (NGINX JavaScript)](https://github.com/nginx/njs) modules, packaged
 as Docker images.
 
 ## Layout
@@ -40,7 +40,9 @@ mc/MinIO client).
 - `make test-unit` / `make test-integration` — run just one half of the suite
   against the already-built image.
 - `make test-matrix` — reproduce the CI matrix locally.
-- `make lint` — checkmake + shellcheck.
+- `make lint` — checkmake + shellcheck + rumdl (Markdown).
+- `make lint-md` / `make fmt-md` — report or auto-fix Markdown issues with
+  `rumdl` (config in `.rumdl.toml`) without running the other linters.
 - `make docs` — generate JSDoc reference documentation.
 
 Notes:
@@ -231,7 +233,9 @@ A new environment variable is never just a code change. The full checklist:
   keep the syntax POSIX. Use spaces, not commas, to separate values in
   env-var lists.
 - No whitespace or reformatting churn in PRs: revert changes outside the lines
-  you mean to touch, and disable markdown autoformatters.
+  you mean to touch. The one sanctioned exception is Markdown: `rumdl` (config
+  in `.rumdl.toml`, run via `make lint-md` / `make fmt-md`) is the project's
+  formatter for `.md` files, so its changes are expected, not churn.
 
 ## Git and PR conventions
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,7 +2,10 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste,
+color, religion, or sexual identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
@@ -26,53 +29,70 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take
+appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing
+the community in public spaces. Examples of representing our community include using an official email address, posting
+via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <nginx-oss-community@f5.com>. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible
+for enforcement at <nginx-oss-community@f5.com>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem
+in violation of this Code of Conduct:
 
 ### 1. Correction
 
 **Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation
+and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
 **Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social media. Violating these terms may lead to a
+temporary or permanent ban.
 
 ### 3. Temporary Ban
 
 **Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified
+period of time. No public or private interaction with the people involved, including unsolicited interaction with those
+enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate
+behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1,
+available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by
 [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
-For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>.
+Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Contributing Guidelines
 
-The following is a set of guidelines for contributing to this project. We really appreciate that you are considering contributing!
+The following is a set of guidelines for contributing to this project. We really appreciate that you are considering
+contributing!
 
-#### Table Of Contents
+## Table Of Contents
 
 [Getting Started](#getting-started)
 
@@ -20,24 +21,34 @@ Refer to the [Getting Started Guide](docs/getting_started.md) for how to build a
 
 ### Report a Bug
 
-To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](/SECURITY.md).**
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please
+ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using
+our [security policy](/SECURITY.md).**
 
 ### Suggest a Feature or Enhancement
 
-To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
+To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available
+[feature request template](/.github/feature_request_template.md). Please ensure the feature or enhancement has not
+already been suggested.
 
 ### Open a Pull Request (PR)
 
-- Fork the repo, create a branch, implement your changes, add any relevant tests, and submit a PR when your changes are **tested** and ready for review.
+- Fork the repo, create a branch, implement your changes, add any relevant tests, and submit a PR when your changes are
+  **tested** and ready for review.
 - Fill in the [PR template](/.github/pull_request_template.md).
 
-**Note:** If you'd like to implement a new feature, please consider creating a [feature request issue](/.github/feature_request_template.md) first to start a discussion about the feature.
+**Note:** If you'd like to implement a new feature, please consider creating a
+[feature request issue](/.github/feature_request_template.md) first to start a discussion about the feature.
 
 #### F5 Contributor License Agreement (CLA)
 
-F5 requires all external contributors to agree to the terms of the F5 CLA (available [here](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md)) before any of their changes can be incorporated into an F5 Open Source repository.
+F5 requires all external contributors to agree to the terms of the
+[F5 CLA](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md) before any of their changes can be incorporated
+into an F5 Open Source repository.
 
-If you have not yet agreed to the F5 CLA terms and submit a PR to this repository, a bot will prompt you to view and agree to the F5 CLA. You will have to agree to the F5 CLA terms through a comment in the PR before any of your changes can be merged. Your agreement signature will be safely stored by F5 and no longer be required in future PRs.
+If you have not yet agreed to the F5 CLA terms and submit a PR to this repository, a bot will prompt you to view and
+agree to the F5 CLA. You will have to agree to the F5 CLA terms through a comment in the PR before any of your changes
+can be merged. Your agreement signature will be safely stored by F5 and no longer be required in future PRs.
 
 ## Code Guidelines
 
@@ -45,11 +56,15 @@ If you have not yet agreed to the F5 CLA terms and submit a PR to this repositor
 
 ### Git Guidelines
 
-- Keep a clean, concise and meaningful git commit history on your branch (within reason), rebasing locally and squashing before submitting a PR.
-- If possible and/or relevant, use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format when writing a commit message, so that changelogs can be automatically generated.
-- Follow the guidelines of writing a good commit message as described here <https://chris.beams.io/posts/git-commit/> and summarized in the next few points:
+- Keep a clean, concise and meaningful git commit history on your branch (within reason), rebasing locally and squashing
+  before submitting a PR.
+- If possible and/or relevant, use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
+  when writing a commit message, so that changelogs can be automatically generated.
+- Follow the guidelines of writing a good commit message as described here <https://chris.beams.io/posts/git-commit/>
+  and summarized in the next few points:
   - In the subject line, use the present tense ("Add feature" not "Added feature").
   - In the subject line, use the imperative mood ("Move cursor to..." not "Moves cursor to...").
   - Limit the subject line to 72 characters or less.
   - Reference issues and pull requests liberally after the subject line.
-  - Add more detailed description in the body of the git message (`git commit -a` to give you more space and time in your text editor to write a good message instead of `git commit -am`).
+  - Add more detailed description in the body of the git message (`git commit -a` to give you more space and time in
+    your text editor to write a good message instead of `git commit -am`).

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -69,7 +69,7 @@ SHELL_SCRIPTS     := test.sh \
 SHELLCHECK_EXCLUDES := SC2027,SC2034,SC2068,SC2140
 
 # Single line on purpose: checkmake's parser does not follow continuations
-.PHONY: help check-tools check-nginx-type check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck hadolint docs docs-open jsdoc clean clean-images all ci
+.PHONY: help check-tools check-nginx-type check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck lint-md fmt-md hadolint docs docs-open jsdoc clean clean-images all ci
 
 ##@ Help
 
@@ -95,7 +95,7 @@ check-tools: ## Verify required build and test tooling is present
 	if ! command -v md5sum > /dev/null 2>&1 && ! command -v md5 > /dev/null 2>&1; then \
 		echo "MISSING (required): md5sum (or md5 on macOS)"; ok=0; \
 	fi; \
-	for tool in npx checkmake shellcheck; do \
+	for tool in npx checkmake shellcheck rumdl; do \
 		command -v "$$tool" > /dev/null 2>&1 || echo "missing (optional, needed for lint/docs): $$tool"; \
 	done; \
 	for tool in hadolint jq; do \
@@ -246,7 +246,7 @@ retest-unprivileged: check-nginx-type check-tools ## Test the current image in u
 
 ##@ Lint
 
-lint: makefile-check shellcheck ## Run all linters (checkmake + shellcheck)
+lint: makefile-check shellcheck lint-md ## Run all linters (checkmake + shellcheck + rumdl)
 	@echo "All lints passed"
 
 makefile-check: ## Lint this Makefile with checkmake
@@ -255,6 +255,12 @@ makefile-check: ## Lint this Makefile with checkmake
 shellcheck: ## Lint shell scripts (pre-existing findings excluded, see SHELLCHECK_EXCLUDES)
 	cd "$(BASE_DIR)" && shellcheck --severity=warning \
 		--exclude=$(SHELLCHECK_EXCLUDES) $(SHELL_SCRIPTS)
+
+lint-md: ## Lint Markdown docs with rumdl (report only, config in .rumdl.toml)
+	cd "$(BASE_DIR)" && rumdl check .
+
+fmt-md: ## Apply rumdl's automatic Markdown formatting fixes in place
+	cd "$(BASE_DIR)" && rumdl fmt .
 
 hadolint: ## Lint Dockerfiles with hadolint when installed (opt-in, not part of lint)
 	@if command -v hadolint > /dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ service. This allows you to proxy a private S3 bucket without requiring users
 to authenticate to it. Within the proxy layer, additional functionality can be
 configured such as:
 
- * Listing the contents of a S3 bucket
- * Providing an authentication gateway using an alternative authentication
-   system to S3
- * Caching frequently accessed S3 objects for lower latency delivery and
-   protection against S3 outages
- * For internal/micro services that can't authenticate against the S3 API
-   (e.g. don't have libraries available) the gateway can provide a means
-   to accessing S3 objects without authentication
- * Compressing objects ([gzip](examples/gzip-compression), [brotli](examples/brotli-compression)) from gateway to end user
- * Protecting S3 bucket from arbitrary public access and traversal
- * Rate limiting S3 objects
- * Protecting a S3 bucket with a [WAF](examples/modsecurity)
- * Serving static assets from a S3 bucket alongside a dynamic application
-   endpoints all in a single RESTful directory structure
+- Listing the contents of a S3 bucket
+- Providing an authentication gateway using an alternative authentication
+  system to S3
+- Caching frequently accessed S3 objects for lower latency delivery and
+  protection against S3 outages
+- For internal/micro services that can't authenticate against the S3 API
+  (e.g. don't have libraries available) the gateway can provide a means
+  to accessing S3 objects without authentication
+- Compressing objects ([gzip](examples/gzip-compression), [brotli](examples/brotli-compression)) from gateway to end user
+- Protecting S3 bucket from arbitrary public access and traversal
+- Rate limiting S3 objects
+- Protecting a S3 bucket with a [WAF](examples/modsecurity)
+- Serving static assets from a S3 bucket alongside a dynamic application
+  endpoints all in a single RESTful directory structure
 
 All such functionality can be enabled within a standard NGINX configuration
 because this project is nothing other than NGINX with additional configuration
@@ -58,7 +58,7 @@ and run the gateway.
 
 ## Directory Structure and File Descriptions
 
-```
+```text
 common/                          contains files used by both NGINX OSS and Plus configurations
   etc/nginx/include/
     awscredentials.js            common library to read and write credentials

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,17 @@
 
 ## Latest Versions
 
-We advise users to run or update to the most recent release of this project. Older versions of this project may not have all enhancements and/or bug fixes applied to them.
+We advise users to run or update to the most recent release of this project.
+Older versions of this project may not have all enhancements and/or bug fixes
+applied to them.
 
 ## Reporting a Vulnerability
 
 The F5 Security Incident Response Team (F5 SIRT) has an email alias that makes it easy to report potential security vulnerabilities:
 
 - If you’re an F5 customer with an active support contract, please contact [F5 Technical Support](https://www.f5.com/services/support).
-- If you aren’t an F5 customer, please report any potential or current instances of security vulnerabilities with any F5 product to the F5 Security Incident Response Team at <F5SIRT@f5.com>.
+- If you aren’t an F5 customer, please report any potential or current
+  instances of security vulnerabilities with any F5 product to the F5
+  Security Incident Response Team at <F5SIRT@f5.com>.
 
 For more information visit [https://www.f5.com/services/support/report-a-vulnerability](https://www.f5.com/services/support/report-a-vulnerability).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,15 +4,20 @@
 
 We use GitHub for tracking bugs and feature requests related to this project.
 
-Don't know how something in this project works? Curious if this project can achieve your desired functionality? Please open an issue on GitHub with the label `question`. Alternatively, start a GitHub discussion!
+Don't know how something in this project works? Curious if this project can achieve your desired functionality?
+Please open an issue on GitHub with the label `question`. Alternatively, start a GitHub discussion!
 
 ## NGINX Specific Questions and/or Issues
 
-This isn't the right place to get support for NGINX specific questions, but the following resources are available below. Thanks for your understanding!
+This isn't the right place to get support for NGINX specific questions, but the following resources are
+available below. Thanks for your understanding!
 
 ### Community Forum
 
-We have a community [forum](https://community.nginx.org/)! If you have any questions and/or issues, try checking out the [`Troubleshooting`](https://community.nginx.org/c/troubleshooting/8) and [`How do I...?`](https://community.nginx.org/c/how-do-i/9) categories. Both fellow community members and NGINXers might be able to help you! :)
+We have a community [forum](https://community.nginx.org/)! If you have any questions and/or issues, try checking
+out the [`Troubleshooting`](https://community.nginx.org/c/troubleshooting/8) and
+[`How do I...?`](https://community.nginx.org/c/how-do-i/9) categories. Both fellow community members and NGINXers
+might be able to help you! :)
 
 ### Documentation
 
@@ -26,8 +31,10 @@ Want to get in touch with the NGINX development team directly? Try using the rel
 
 ## Contributing
 
-Please see the [contributing guide](/CONTRIBUTING.md) or the [Getting Started](/README.md#getting-started) guide, for guidelines on how to best contribute to this project.
+Please see the [contributing guide](/CONTRIBUTING.md) or the [Getting Started](/README.md#getting-started) guide,
+for guidelines on how to best contribute to this project.
 
 ## Community Support
 
-This project does **not** offer commercial support. Community support is offered on a best effort basis through either GitHub issues/PRs/discussions or through any of our active communities.
+This project does **not** offer commercial support. Community support is offered on a best effort basis through
+either GitHub issues/PRs/discussions or through any of our active communities.

--- a/deployments/s3_express/README.md
+++ b/deployments/s3_express/README.md
@@ -1,7 +1,9 @@
 # Purpose
+
 This Terraform script sets up an AWS S3 Express One Zone bucket for testing.
 
 ## Usage
+
 Use environment variables to authenticate:
 
 ```bash
@@ -11,6 +13,7 @@ export AWS_REGION="us-west-2"
 ```
 
 Generate a plan:
+
 ```bash
 terraform plan -out=plan.tfplan \
 >   -var="bucket_name=my-bucket-name--usw2-az1--x-s3" \
@@ -18,16 +21,24 @@ terraform plan -out=plan.tfplan \
 >   -var="availability_zone_id=usw2-az1" \
 >   -var="owner_email=my_email@foo.com"
 ```
-> [!NOTE] 
-> Note that AWS S3 Express One Zone is only available in [certain regions and availability zones](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-networking.html#s3-express-endpoints). If you get an error like this: `api error InvalidBucketName`.  If you have met the [naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html), this likely means you have chosen a bad region/availability zone combination.
 
+> [!NOTE]
+> Note that AWS S3 Express One Zone is only available in
+> [certain regions and availability zones][s3-express-endpoints]. If you get an error like this:
+> `api error InvalidBucketName`. If you have met the [naming rules][bucket-naming-rules], this likely means you have
+> chosen a bad region/availability zone combination.
+
+[s3-express-endpoints]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-networking.html#s3-express-endpoints
+[bucket-naming-rules]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html
 
 If you are comfortable with the plan, apply it:
-```
+
+```text
 terraform apply "plan.tfplan"
 ```
 
 Then build the image (you can also use the latest release)
+
 ```bash
 docker build --file Dockerfile.oss --tag nginx-s3-gateway:oss --tag nginx-s3-gateway .
 ```
@@ -40,6 +51,7 @@ docker run --rm --env-file ./settings.s3express.example --publish 80:80 --name n
 ```
 
 Confirm that it is working. The terraform script will prepopulate the bucket with a single test object
+
 ```bash
 curl http://localhost:80/test.txt
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,18 +2,18 @@
 
 ## Integrating with AWS Signature
 
-Update the following files when enhancing `nginx-s3-gateway` to integrate with AWS signature whenever AWS releases a new version of signature or you have a new PR:
+Update the following files when enhancing `nginx-s3-gateway` to integrate with AWS signature whenever AWS releases a
+new version of signature or you have a new PR:
 
 - NGINX Proxy: [`/etc/nginx/conf.d/default.conf`](/common/etc/nginx/templates/default.conf.template)
 - AWS Credentials Lib: [`/etc/nginx/include/awscredentials.js`](/common/etc/nginx/include/awscredentials.js)
 - AWS Signature Lib per version:
   - [`/etc/nginx/include/awssig2.js`](/common/etc/nginx/include/awssig2.js)
   - [`/etc/nginx/include/awssig4.js`](/common/etc/nginx/include/awssig4.js)
-
 - S3 Integration Lib: [`/etc/nginx/include/s3gateway.js`](/common/etc/nginx/include/s3gateway.js)
 - Common Lib for all of NJS: [`/etc/nginx/include/utils.js`](/common/etc/nginx/include/utils.js)
 
-![](./img/nginx-s3-gateway-signature-flow.png)
+![AWS signature flow across the njs modules](./img/nginx-s3-gateway-signature-flow.png)
 
 ## Extending the Gateway
 
@@ -21,7 +21,7 @@ Update the following files when enhancing `nginx-s3-gateway` to integrate with A
 
 #### `conf.d` Directory
 
-On the container image, all files with the extension `.conf` in the 
+On the container image, all files with the extension `.conf` in the
 directory `/etc/nginx/conf.d` will be loaded into the configuration
 of the base `http` block within the main NGINX configuration.
 
@@ -35,9 +35,9 @@ The NGINX configuration templates render into `/etc/nginx/conf.d` when the
 container starts. The gateway ships three empty stub files in the `gateway/`
 subdirectory that exist purely as extension points:
 
-* [`/etc/nginx/conf.d/gateway/s3_server.conf`](/common/etc/nginx/templates/gateway/s3_server.conf.template)
-* [`/etc/nginx/conf.d/gateway/s3_location.conf`](/common/etc/nginx/templates/gateway/s3_location.conf.template)
-* [`/etc/nginx/conf.d/gateway/s3listing_location.conf`](/common/etc/nginx/templates/gateway/s3listing_location.conf.template)
+- [`/etc/nginx/conf.d/gateway/s3_server.conf`](/common/etc/nginx/templates/gateway/s3_server.conf.template)
+- [`/etc/nginx/conf.d/gateway/s3_location.conf`](/common/etc/nginx/templates/gateway/s3_location.conf.template)
+- [`/etc/nginx/conf.d/gateway/s3listing_location.conf`](/common/etc/nginx/templates/gateway/s3listing_location.conf.template)
 
 Each of these files can be overwritten in a container image that inherits
 from the S3 Gateway container image, so that additional NGINX configuration
@@ -45,13 +45,13 @@ directives can be inserted into the gateway configuration.
 
 ### Examples
 
-In the [examples/ directory](/examples), there are `Dockerfile` examples that 
+In the [examples/ directory](/examples), there are `Dockerfile` examples that
 show how to extend the base functionality of the NGINX S3 Gateway by adding
 additional modules.
 
-* [Enabling Brotli Compression in Docker](/examples/brotli-compression)
-* [Enabling GZip Compression in Docker](/examples/gzip-compression)
-* [Installing Modsecurity in Docker](/examples/modsecurity)
+- [Enabling Brotli Compression in Docker](/examples/brotli-compression)
+- [Enabling GZip Compression in Docker](/examples/gzip-compression)
+- [Installing Modsecurity in Docker](/examples/modsecurity)
 
 ## Testing
 
@@ -68,7 +68,7 @@ installed; run `make check-tools` to verify all prerequisites are present.
 
 To build the gateway image and run the full unit and integration test suite:
 
-```
+```text
 $ make test                  # NGINX OSS (default)
 $ make test NGINX_TYPE=plus  # NGINX Plus
 ```
@@ -81,15 +81,15 @@ repository root or at `/etc/nginx/license.jwt` for the integration tests.
 
 Other useful targets:
 
-* `make retest` — rerun tests against the already-built image. Note that unit
+- `make retest` — rerun tests against the already-built image. Note that unit
   tests import the njs modules baked into the image, so after editing
   `common/etc/nginx/include/*.js` use `make test` to rebuild first.
-* `make test-unit` / `make test-integration` — run just the unit or just the
+- `make test-unit` / `make test-integration` — run just the unit or just the
   integration half of the suite against the already-built image.
-* `make test-latest-njs` / `make test-unprivileged` — build and test the
+- `make test-latest-njs` / `make test-unprivileged` — build and test the
   image variants.
-* `make test-matrix` — reproduce the CI matrix locally.
-* `make lint` — run the linters (checkmake + shellcheck).
+- `make test-matrix` — reproduce the CI matrix locally.
+- `make lint` — run the linters (checkmake + shellcheck).
 
 Run `make help` for the full target list.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -15,101 +15,109 @@
 The following environment variables are used to configure the gateway when
 running as a Container or as a Systemd service.
 
-| Name                                  | Required? | Allowed Values               | Default   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ------------------------------------- | --------- | ---------------------------- | --------- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ALLOW_DIRECTORY_LIST`                | Yes       | `true`, `false`              | `false`   | Flag enabling directory listing                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `AWS_SIGS_VERSION`                    | Yes       | 2, 4                         |           | AWS Signatures API version                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `AWS_ACCESS_KEY_ID`                   | Yes       |                              |           | Access key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `AWS_SECRET_ACCESS_KEY`               | Yes       |                              |           | Secret access key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `AWS_SESSION_TOKEN`                   | No        |                              |           | Session token.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `S3_BUCKET_NAME`                      | Yes       |                              |           | Name of S3 bucket to proxy requests to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `S3_REGION`                           | Yes       |                              |           | Region associated with API                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `S3_SERVER_PORT`                      | Yes       |                              |           | SSL/TLS port to connect to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `S3_SERVER_PROTO`                     | Yes       | `http`, `https`              |           | Protocol to used connect to S3 server                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `S3_SERVER`                           | Yes       |                              |           | S3 host to connect to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `S3_STYLE`                            | Yes       | `virtual-v2`, `virtual`, `path`, `default` | `default` | The S3 host/path method. <br><br>`virtual` and `virtual-v2` represent the method that uses DNS-style bucket+hostname:port. The `default` is the same as `virtual`. In the future, the `default` value will become `virtual-v2`. See [Choosing a `S3_STYLE` Setting](#user-content-choosing-a-s3_style-setting) below for details. <br><br>`path` is a method that appends the bucket name as the first directory in the URI's path. This method is used by many S3 compatible services. See this [AWS blog article](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) for further information. |
-| `S3_SERVICE`                          | Yes       | `s3`, `s3express`            | `s3`      | Configures the gateway to interface with either normal S3 buckets or S3 Express One Zone                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `DEBUG`                               | No        | `true`, `false`              | `false`   | Flag enabling AWS signatures debug output                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` | No        | `true`, `false`              | `false`   | Flag enabling the return a 302 with a `/` appended to the path. This is independent of the behavior selected in `ALLOW_DIRECTORY_LIST` or `PROVIDE_INDEX_PAGE`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `DIRECTORY_LISTING_PATH_PREFIX`       | No        |                              |           | In `ALLOW_DIRECTORY_LIST=true` mode [adds defined prefix to links](#configuring-directory-listing)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `FOUR_O_FOUR_ON_EMPTY_BUCKET`         | No        | `true`, `false`              | `false`   | In `ALLOW_DIRECTORY_LIST=true` mode, return `404 Not Found` instead of an empty directory listing when a bucket or path prefix contains no objects                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `DNS_RESOLVERS`                       | No        |                              |           | DNS resolvers (separated by single spaces) to configure NGINX with                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `PROXY_CACHE_MAX_SIZE`                | No        |                              | `10g`     | Limits cache size                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `PROXY_CACHE_INACTIVE`                | No        |                              | `60m`     | Cached data that are not accessed during the time specified by the parameter get removed from the cache regardless of their freshness                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `PROXY_CACHE_SLICE_SIZE`              | No        |                              | `1m`      | For requests with a `Range` header included, determines the size of the chunks in which the file is fetched. Values much smaller than the requests can lead to inefficiencies due to reading and writing many files. See [below for more details](#byte-range-requests-and-caching)                                                                                                                                                                                                                                                                                                                                                   |
-| `PROXY_CACHE_VALID_OK`                | No        |                              | `1h`      | Sets caching time for response code 200 and 302                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `PROXY_CACHE_VALID_NOTFOUND`          | No        |                              | `1m`      | Sets caching time for response code 404                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `PROXY_CACHE_VALID_FORBIDDEN`         | No        |                              | `30s`     | Sets caching time for response code 403                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `PROXY_CACHE_USE_STALE`               | No        |                              | `error timeout http_500 http_502 http_503 http_504` | Sets conditions under which stale cached data can be used. See [here](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_use_stale) for more details                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `PROXY_CACHE_BYPASS_NO_CACHE`         | No        | `true`, `false`              | `false`   | When `true`, a request whose `Cache-Control` header contains the `no-cache` directive (for example a browser hard refresh) bypasses the local cache and fetches a fresh copy from S3. Off by default because clients can use it to drive up S3 request costs. See [Bypassing the Local Cache with Cache-Control: no-cache](#bypassing-the-local-cache-with-cache-control-no-cache)                                                                                                                                                                                                                                                         |
-| `PROVIDE_INDEX_PAGE`                  | No        | `true`, `false`              | `false`   | Flag which returns the index page if there is one when requesting a directory.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| `JS_TRUSTED_CERT_PATH`                | No        |                              |           | Enables the `js_fetch_trusted_certificate` directive when retrieving AWS credentials and sets the path (on the container) to the specified path                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `HEADER_PREFIXES_TO_STRIP`            | No        |                              |           | A list of HTTP header prefixes that exclude headers from client responses. List should be specified in lower-case and a semicolon (;) should be used to as a delimiter between values. For example: x-goog-;x-something-. Headers starting with x-amz- will be stripped by default for security reasons unless explicitly added in HEADER_PREFIXES_ALLOWED.                                                                                                                                                                                                                                                                           |
-| `HEADER_PREFIXES_ALLOWED`             | No        |                              |           | A list of allowed prefixes for HTTP headers that are returned to the client in responses. List should be specified in lower-case and a semicolon (;) should be used to as a delimiter between values. For example: x-amz-;x-something-. It is NOT recommended to return x-amz- headers for security reasons. Think carefully about what is allowed here.                                                                                                                                                                                                                                                                              |
-| `CORS_ENABLED`                        | No        | `true`, `false`              | `false`   | Flag that enables CORS headers on GET requests and enables pre-flight OPTIONS requests. If enabled, this will add CORS headers for "fully open" cross domain requests by default, meaning all domains are allowed, similar to the settings show in [this example](https://enable-cors.org/server_nginx.html). CORS settings can be fine-tuned by overwriting the [`cors.conf.template`](/common/etc/nginx/templates/gateway/cors.conf.template) file.                                                                                                                                                                                 |
-| `CORS_ALLOWED_ORIGIN`                 | No        |                              |           | Value to set to be returned from the CORS `Access-Control-Allow-Origin` header. This value is only used if CORS is enabled. (default: \*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `STRIP_LEADING_DIRECTORY_PATH`        | No        |                              |           | Removes a portion of the path in the requested URL (if configured). Useful when deploying to an ALB under a folder (eg. www.mysite.com/somepath).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `PREFIX_LEADING_DIRECTORY_PATH`       | No        |                              |           | Prefix to prepend to all S3 object paths. Useful to serve only a subset of an S3 bucket. When used in combination with `STRIP_LEADING_DIRECTORY_PATH`, this allows the leading path to be replaced, rather than just removed.                                                                                                                                                                                                                                                                                                                                                                                                         |
-| `CORS_ALLOW_PRIVATE_NETWORK_ACCESS`   | No        | `true`, `false`              |           | Flag that enables responding to the CORS OPTIONS pre-flight request header `Access-Control-Request-Private-Network` with the `Access-Control-Allow-Private-Network` header. If the value is "true", responds with "true", if "false" responds with "false". If the environment variable is blank/not set, does not respond with any header. This value is only used if CORS is enabled. See [Private Network Access: introducing preflights](https://developer.chrome.com/blog/private-network-access-preflight/) for more information about this header.                                                                             |
-| `IPV6_ENABLED`                        | No        | `true`, `false`              |           | Controls whether the gateway also listens on IPv6 (`[::]`). When blank/not set, IPv6 is enabled automatically only if the runtime kernel supports it (`/proc/net/if_inet6` exists), so IPv4-only hosts and clusters keep working. Set to `true` or `false` to force the listener on or off regardless of detection. Container images only — the standalone install does not run the entrypoint scripts and listens on IPv4 only.                                                                                                                                                                                                      |
-
-
-
+| Name                                  | Required? | Allowed Values                             | Default                                             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------- | --------- | ------------------------------------------ | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ALLOW_DIRECTORY_LIST`                | Yes       | `true`, `false`                            | `false`                                             | Flag enabling directory listing                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `AWS_SIGS_VERSION`                    | Yes       | 2, 4                                       |                                                     | AWS Signatures API version                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `AWS_ACCESS_KEY_ID`                   | Yes       |                                            |                                                     | Access key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `AWS_SECRET_ACCESS_KEY`               | Yes       |                                            |                                                     | Secret access key                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `AWS_SESSION_TOKEN`                   | No        |                                            |                                                     | Session token.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `S3_BUCKET_NAME`                      | Yes       |                                            |                                                     | Name of S3 bucket to proxy requests to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `S3_REGION`                           | Yes       |                                            |                                                     | Region associated with API                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `S3_SERVER_PORT`                      | Yes       |                                            |                                                     | SSL/TLS port to connect to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `S3_SERVER_PROTO`                     | Yes       | `http`, `https`                            |                                                     | Protocol to used connect to S3 server                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `S3_SERVER`                           | Yes       |                                            |                                                     | S3 host to connect to                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `S3_STYLE`                            | Yes       | `virtual-v2`, `virtual`, `path`, `default` | `default`                                           | The S3 host/path method. <br><br>`virtual` and `virtual-v2` represent the method that uses DNS-style bucket+hostname:port. The `default` is the same as `virtual`. In the future, the `default` value will become `virtual-v2`. See [Choosing a `S3_STYLE` Setting](#choosing-a-s3_style-setting) below for details. <br><br>`path` is a method that appends the bucket name as the first directory in the URI's path. This method is used by many S3 compatible services. See this [AWS blog article](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) for further information. |
+| `S3_SERVICE`                          | Yes       | `s3`, `s3express`                          | `s3`                                                | Configures the gateway to interface with either normal S3 buckets or S3 Express One Zone                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `DEBUG`                               | No        | `true`, `false`                            | `false`                                             | Flag enabling AWS signatures debug output                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` | No        | `true`, `false`                            | `false`                                             | Flag enabling the return a 302 with a `/` appended to the path. This is independent of the behavior selected in `ALLOW_DIRECTORY_LIST` or `PROVIDE_INDEX_PAGE`.                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `DIRECTORY_LISTING_PATH_PREFIX`       | No        |                                            |                                                     | In `ALLOW_DIRECTORY_LIST=true` mode [adds defined prefix to links](#configuring-directory-listing)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `FOUR_O_FOUR_ON_EMPTY_BUCKET`         | No        | `true`, `false`                            | `false`                                             | In `ALLOW_DIRECTORY_LIST=true` mode, return `404 Not Found` instead of an empty directory listing when a bucket or path prefix contains no objects                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `DNS_RESOLVERS`                       | No        |                                            |                                                     | DNS resolvers (separated by single spaces) to configure NGINX with                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| `PROXY_CACHE_MAX_SIZE`                | No        |                                            | `10g`                                               | Limits cache size                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `PROXY_CACHE_INACTIVE`                | No        |                                            | `60m`                                               | Cached data that are not accessed during the time specified by the parameter get removed from the cache regardless of their freshness                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `PROXY_CACHE_SLICE_SIZE`              | No        |                                            | `1m`                                                | For requests with a `Range` header included, determines the size of the chunks in which the file is fetched. Values much smaller than the requests can lead to inefficiencies due to reading and writing many files. See [below for more details](#byte-range-requests-and-caching)                                                                                                                                                                                                                                                                                                                                      |
+| `PROXY_CACHE_VALID_OK`                | No        |                                            | `1h`                                                | Sets caching time for response code 200 and 302                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `PROXY_CACHE_VALID_NOTFOUND`          | No        |                                            | `1m`                                                | Sets caching time for response code 404                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `PROXY_CACHE_VALID_FORBIDDEN`         | No        |                                            | `30s`                                               | Sets caching time for response code 403                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `PROXY_CACHE_USE_STALE`               | No        |                                            | `error timeout http_500 http_502 http_503 http_504` | Sets conditions under which stale cached data can be used. See the [`proxy_cache_use_stale` directive docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_use_stale) for more details                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `PROXY_CACHE_BYPASS_NO_CACHE`         | No        | `true`, `false`                            | `false`                                             | When `true`, a request whose `Cache-Control` header contains the `no-cache` directive (for example a browser hard refresh) bypasses the local cache and fetches a fresh copy from S3. Off by default because clients can use it to drive up S3 request costs. See [Bypassing the Local Cache with Cache-Control: no-cache](#bypassing-the-local-cache-with-cache-control-no-cache)                                                                                                                                                                                                                                       |
+| `PROVIDE_INDEX_PAGE`                  | No        | `true`, `false`                            | `false`                                             | Flag which returns the index page if there is one when requesting a directory.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `JS_TRUSTED_CERT_PATH`                | No        |                                            |                                                     | Enables the `js_fetch_trusted_certificate` directive when retrieving AWS credentials and sets the path (on the container) to the specified path                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `HEADER_PREFIXES_TO_STRIP`            | No        |                                            |                                                     | A list of HTTP header prefixes that exclude headers from client responses. List should be specified in lower-case and a semicolon (;) should be used to as a delimiter between values. For example: x-goog-;x-something-. Headers starting with x-amz- will be stripped by default for security reasons unless explicitly added in HEADER_PREFIXES_ALLOWED.                                                                                                                                                                                                                                                              |
+| `HEADER_PREFIXES_ALLOWED`             | No        |                                            |                                                     | A list of allowed prefixes for HTTP headers that are returned to the client in responses. List should be specified in lower-case and a semicolon (;) should be used to as a delimiter between values. For example: x-amz-;x-something-. It is NOT recommended to return x-amz- headers for security reasons. Think carefully about what is allowed here.                                                                                                                                                                                                                                                                 |
+| `CORS_ENABLED`                        | No        | `true`, `false`                            | `false`                                             | Flag that enables CORS headers on GET requests and enables pre-flight OPTIONS requests. If enabled, this will add CORS headers for "fully open" cross domain requests by default, meaning all domains are allowed, similar to the settings show in [this example](https://enable-cors.org/server_nginx.html). CORS settings can be fine-tuned by overwriting the [`cors.conf.template`](/common/etc/nginx/templates/gateway/cors.conf.template) file.                                                                                                                                                                    |
+| `CORS_ALLOWED_ORIGIN`                 | No        |                                            |                                                     | Value to set to be returned from the CORS `Access-Control-Allow-Origin` header. This value is only used if CORS is enabled. (default: \*)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `STRIP_LEADING_DIRECTORY_PATH`        | No        |                                            |                                                     | Removes a portion of the path in the requested URL (if configured). Useful when deploying to an ALB under a folder (eg. `www.mysite.com/somepath`).                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `PREFIX_LEADING_DIRECTORY_PATH`       | No        |                                            |                                                     | Prefix to prepend to all S3 object paths. Useful to serve only a subset of an S3 bucket. When used in combination with `STRIP_LEADING_DIRECTORY_PATH`, this allows the leading path to be replaced, rather than just removed.                                                                                                                                                                                                                                                                                                                                                                                            |
+| `CORS_ALLOW_PRIVATE_NETWORK_ACCESS`   | No        | `true`, `false`                            |                                                     | Flag that enables responding to the CORS OPTIONS pre-flight request header `Access-Control-Request-Private-Network` with the `Access-Control-Allow-Private-Network` header. If the value is "true", responds with "true", if "false" responds with "false". If the environment variable is blank/not set, does not respond with any header. This value is only used if CORS is enabled. See [Private Network Access: introducing preflights](https://developer.chrome.com/blog/private-network-access-preflight/) for more information about this header.                                                                |
+| `IPV6_ENABLED`                        | No        | `true`, `false`                            |                                                     | Controls whether the gateway also listens on IPv6 (`[::]`). When blank/not set, IPv6 is enabled automatically only if the runtime kernel supports it (`/proc/net/if_inet6` exists), so IPv4-only hosts and clusters keep working. Set to `true` or `false` to force the listener on or off regardless of detection. Container images only — the standalone install does not run the entrypoint scripts and listens on IPv4 only.                                                                                                                                                                                         |
 
 If you are using [AWS instance profile credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html),
 you will need to omit the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` variables from
 the configuration.
 
-When running with Docker, the above environment variables can be set in a file 
+When running with Docker, the above environment variables can be set in a file
 with the `--env-file` flag. When running as a Systemd service, the environment
 variables are specified in the `/etc/nginx/environment` file. An example of
 the format of the file can be found in the [settings.example](/settings.example)
 file.
-  
+
 There are few optional environment variables that can be used.
 
-* `AWS_ROLE_SESSION_NAME` - (optional) The value will be used for Role Session Name. The default value is nginx-s3-gateway.
-* `STS_ENDPOINT` - (optional) Overrides the STS endpoint to be used in applicable setups. This is not required when running on EKS. See the EKS portion of the guide below for more details.
-* `AWS_STS_REGIONAL_ENDPOINTS` - (optional) Allows for a regional STS endpoint to be
+- `AWS_ROLE_SESSION_NAME` - (optional) The value will be used for Role Session Name. The default value is nginx-s3-gateway.
+- `STS_ENDPOINT` - (optional) Overrides the STS endpoint to be used in applicable setups. This is not required when
+  running on EKS. See the EKS portion of the guide below for more details.
+- `AWS_STS_REGIONAL_ENDPOINTS` - (optional) Allows for a regional STS endpoint to be
   selected. When the regional model is selected then the STS endpoint generated will
   be coded to the current AWS region. This environment variable will be ignored if
   `STS_ENDPOINT` is set. Valid options are: `global` (default) or `regional`.
 
 ### Choosing a `S3_STYLE` Setting
-**If you are using AWS S3 or S3 Express One Zone, use `virtual-v2`.** We are maintaining `virtual` temporarily until we hear from the community that `virtual-v2` does not cause issues - or we introduce a versioning system that allows us to safely flag breaking changes.
+
+**If you are using AWS S3 or S3 Express One Zone, use `virtual-v2`.** We are maintaining `virtual` temporarily until we
+hear from the community that `virtual-v2` does not cause issues - or we introduce a versioning system that allows us to
+safely flag breaking changes.
 Until then, `virtual` works as before, and `default` still causes the `virtual` behavior to be used.
 
 **`virtual-v2` is not expected to be a breaking change** but we are being cautious.
 
-A full reference for S3 addressing styles may be found [here](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
+A full reference for S3 addressing styles may be found in [AWS's virtual hosting documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html)
 
 Here is the difference between `virtual` and `virtual-v2`:
+
 #### virtual
-* Proxied endpoint: `S3_SERVER:S3_SERVER_PORT`
-* `Host` header: `S3_BUCKET_NAME.S3_SERVER`
-* `host` field in the [S3 V4 `CanonicalHeaders`](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html): `S3_BUCKET_NAME.S3_SERVER`
+
+- Proxied endpoint: `S3_SERVER:S3_SERVER_PORT`
+- `Host` header: `S3_BUCKET_NAME.S3_SERVER`
+- `host` field in the [S3 V4 `CanonicalHeaders`](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html): `S3_BUCKET_NAME.S3_SERVER`
 
 #### virtual-v2
+
 All items are set to the same value:
-* Proxied endpoint: `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
-* `Host` header: `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
-* `host` field in the [S3 V4 `CanonicalHeaders`](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html): `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
+
+- Proxied endpoint: `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
+- `Host` header: `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
+- `host` field in the [S3 V4 `CanonicalHeaders`](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html): `S3_BUCKET_NAME.S3_SERVER:S3_SERVER_PORT`
 
 #### path
-`path` style routing does not prepend the bucket name to the host, and includes it as the first segment in the request path.  AWS is actively trying to move away from this method. Some S3 compatible object stores may require that you use this setting - but try to avoid it if your object store works with `virtual-v2`.
 
+`path` style routing does not prepend the bucket name to the host, and includes it as the first segment in the request
+path. AWS is actively trying to move away from this method. Some S3 compatible object stores may require that you use
+this setting - but try to avoid it if your object store works with `virtual-v2`.
 
 ### Configuring Directory Listing
 
 Listing of S3 directories ([folders](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-folders.html)) is supported when the
-`ALLOW_DIRECTORY_LIST` environment variable is set to `1`. Directory listing 
+`ALLOW_DIRECTORY_LIST` environment variable is set to `1`. Directory listing
 output can be customized by changing the
 [XSL stylesheet](https://www.w3schools.com/xml/xsl_intro.asp): [`common/etc/nginx/include/listing.xsl`](/common/etc/nginx/include/listing.xsl).
-If you are not using AWS S3 as your backend, you may see some inconsistency in 
+If you are not using AWS S3 as your backend, you may see some inconsistency in
 the behavior with how directory listing works with HEAD requests. Additionally,
-due to limitations in proxy response processing, invalid S3 folder requests will 
+due to limitations in proxy response processing, invalid S3 folder requests will
 result in log messages like:
-```
+
+```text
  libxml2 error: "Extra content at the end of the document"
 ```
 
@@ -124,105 +132,149 @@ the path of the files returned from the listing.
 Using the `DIRECTORY_LISTING_PATH_PREFIX` environment variable will allow
 one to add that prefix in listing page's header and links.
 
-For example, if one configures to `DIRECTORY_LISTING_PATH_PREFIX='main/'` and 
-then uses HAProxy to proxy the gateway with the 
+For example, if one configures to `DIRECTORY_LISTING_PATH_PREFIX='main/'` and
+then uses HAProxy to proxy the gateway with the
 `http-request set-path %[path,regsub(^/main,/)]` setting, the architecture
-will look like the following: 
+will look like the following:
 
-![](./img/nginx-s3-gateway-directory-listing-path-prefix.png)
+![Architecture diagram of HAProxy stripping a path prefix in front of the gateway](./img/nginx-s3-gateway-directory-listing-path-prefix.png)
 
 ### Static Site Hosting
 
 When `PROVIDE_INDEX_PAGE` environment variable is set to 1, the gateway will
 transform `/some/path/` to `/some/path/index.html` when retrieving from S3.  
-Default of "index.html" can be edited in `s3gateway.js`. 
-It will also redirect `/some/path` to `/some/path/` when S3 returns 404 on 
-`/some/path` if `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is set. `path` has to 
-look like a possible directory: it must not end with a slash, and its final 
-path segment must not contain a dot. Only the final segment is checked, so a 
-dot in an intermediate directory (e.g. `/dir.name/file`) does not prevent 
-the redirect, while any dot in the final segment (e.g. `/file.jpg`, 
-`/releases/v1.2.3`, `/.hidden`, `/reports.`) is treated as a file extension 
-and is not redirected. The path is percent-decoded before this check, so an 
-encoded dot (`%2E`) counts as a dot and an encoded slash (`%2F`) counts as a 
-directory separator (e.g. `/foo%2F` is treated as a directory and is not 
+Default of "index.html" can be edited in `s3gateway.js`.
+It will also redirect `/some/path` to `/some/path/` when S3 returns 404 on
+`/some/path` if `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY` is set. `path` has to
+look like a possible directory: it must not end with a slash, and its final
+path segment must not contain a dot. Only the final segment is checked, so a
+dot in an intermediate directory (e.g. `/dir.name/file`) does not prevent
+the redirect, while any dot in the final segment (e.g. `/file.jpg`,
+`/releases/v1.2.3`, `/.hidden`, `/reports.`) is treated as a file extension
+and is not redirected. The path is percent-decoded before this check, so an
+encoded dot (`%2E`) counts as a dot and an encoded slash (`%2F`) counts as a
+directory separator (e.g. `/foo%2F` is treated as a directory and is not
 redirected).  
 
 ### Hosting a Bucket as a Subfolder on an ALB
 
 The `STRIP_LEADING_DIRECTORY_PATH` environment variable allows one to host an
-S3 bucket in a subfolder on an ALB.  For example, if you wanted to expose the
-root of a bucket under the path "www.mysite.com/somepath", you would set this
-variable to "/somepath".
+S3 bucket in a subfolder on an ALB. For example, if you wanted to expose the
+root of a bucket under the path `www.mysite.com/somepath`, you would set this
+variable to `/somepath`.
 
 ## Byte-Range Requests and Caching
-The gateway caches [byte-range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) (requests sent with a `Range` header) requests differently than normal requests.
 
-The gateway is configured to cache such requests in chunks of size `PROXY_CACHE_SLICE_SIZE`. If you don't provide this configuration value it will default to 1 megabyte.
+The gateway caches [byte-range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) (requests sent with a
+`Range` header) requests differently than normal requests.
+
+The gateway is configured to cache such requests in chunks of size `PROXY_CACHE_SLICE_SIZE`. If you don't provide this
+configuration value it will default to 1 megabyte.
 
 This means that if you request 2.5 megabytes of a 1 gigabyte file, the gateway will cache 3 megabytes and nothing else.
 
-Setting your slice size too small can have performance impacts since NGINX performs a subrequest for each slice. For more details see the [official reference](http://nginx.org/en/docs/http/ngx_http_slice_module.html).
+Setting your slice size too small can have performance impacts since NGINX performs a subrequest for each slice. For
+more details see the [official reference](http://nginx.org/en/docs/http/ngx_http_slice_module.html).
 
-You may make byte-range requests and normal requests for the same file and NGINX will automatically handle them differently.  The caches for file chunks and normal file requests are separate on disk.
+You may make byte-range requests and normal requests for the same file and NGINX will automatically handle them
+differently. The caches for file chunks and normal file requests are separate on disk.
 
 ## Bypassing the Local Cache with Cache-Control: no-cache
-By default the gateway ignores the client's `Cache-Control` request header and serves cached objects until the corresponding `PROXY_CACHE_VALID_*` time expires.
 
-Setting `PROXY_CACHE_BYPASS_NO_CACHE=true` makes the gateway honor the `no-cache` request directive from [RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.4): a request whose `Cache-Control` header contains a `no-cache` token (sent by browsers on a hard refresh such as Ctrl+F5) bypasses the local cache and fetches a fresh copy from S3. The fresh response also replaces the cache entry it bypassed, so subsequent normal requests for that entry are served the updated content. The bypass applies to byte-range requests served from the slice cache as well.
+By default the gateway ignores the client's `Cache-Control` request header and serves cached objects until the
+corresponding `PROXY_CACHE_VALID_*` time expires.
 
-A bypassing request only refreshes the cache entries it actually touches. Cache entries are scoped per request method and per cache zone: full-body `GET` responses, `HEAD` responses, and each slice of a byte-range response are cached independently, so for example a hard-refreshed `GET` does not refresh the `HEAD` entry or any cached slices for the same object. In particular, a `no-cache` byte-range request re-fetches only the slices covered by its `Range` header — if the object changed in S3, the remaining slices keep the previous version until they expire, and NGINX's slice module aborts responses that would mix slices from two object versions (`etag mismatch in slice response` in the error log). A bypassing request also cannot fall back to stale content: `PROXY_CACHE_USE_STALE` only applies to requests served through the cache, so during an S3 outage a hard refresh returns an error even when a usable cached copy exists.
+Setting `PROXY_CACHE_BYPASS_NO_CACHE=true` makes the gateway honor the `no-cache` request directive from
+[RFC 9111](https://www.rfc-editor.org/rfc/rfc9111.html#section-5.2.1.4): a request whose `Cache-Control` header
+contains a `no-cache` token (sent by browsers on a hard refresh such as Ctrl+F5) bypasses the local cache and
+fetches a fresh copy from S3. The fresh response also replaces the cache entry it bypassed, so subsequent normal
+requests for that entry are served the updated content. The bypass applies to byte-range requests served from
+the slice cache as well.
 
-The match is token-aware and case-insensitive. Only a syntactically valid `no-cache` directive triggers a bypass — for example `Cache-Control: no-cache` or `Cache-Control: max-age=0, no-cache`. The following do *not* trigger a bypass: `max-age=0` alone, `no-store`, the legacy `Pragma: no-cache` header, or `no-cache` appearing as a substring of another token.
+A bypassing request only refreshes the cache entries it actually touches. Cache entries are scoped per request method
+and per cache zone: full-body `GET` responses, `HEAD` responses, and each slice of a byte-range response are cached
+independently, so for example a hard-refreshed `GET` does not refresh the `HEAD` entry or any cached slices for the same
+object. In particular, a `no-cache` byte-range request re-fetches only the slices covered by its `Range` header — if the
+object changed in S3, the remaining slices keep the previous version until they expire, and NGINX's slice module aborts
+responses that would mix slices from two object versions (`etag mismatch in slice response` in the error log). A
+bypassing request also cannot fall back to stale content: `PROXY_CACHE_USE_STALE` only applies to requests served
+through the cache, so during an S3 outage a hard refresh returns an error even when a usable cached copy exists.
+
+The match is token-aware and case-insensitive. Only a syntactically valid `no-cache` directive triggers a bypass — for
+example `Cache-Control: no-cache` or `Cache-Control: max-age=0, no-cache`. The following do *not* trigger a bypass:
+`max-age=0` alone, `no-store`, the legacy `Pragma: no-cache` header, or `no-cache` appearing as a substring of another
+token.
 
 > [!WARNING]
-> Enabling this feature lets any client force requests through to S3 by sending a header, defeating the cache. On a publicly reachable gateway this can be abused to increase your S3 request costs and origin load (this is the same reason CDNs such as CloudFront ignore the viewer's `Cache-Control` header). Bypassing requests also skip `proxy_cache_lock`, so N concurrent `no-cache` requests for the same object each open their own S3 fetch instead of being collapsed into one. Enable it only when clients are trusted, or pair it with [rate limiting](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html).
+> Enabling this feature lets any client force requests through to S3 by sending a header, defeating the cache. On a
+> publicly reachable gateway this can be abused to increase your S3 request costs and origin load (this is the same
+> reason CDNs such as CloudFront ignore the viewer's `Cache-Control` header). Bypassing requests also skip
+> `proxy_cache_lock`, so N concurrent `no-cache` requests for the same object each open their own S3 fetch instead of
+> being collapsed into one. Enable it only when clients are trusted, or pair it with
+> [rate limiting](https://nginx.org/en/docs/http/ngx_http_limit_req_module.html).
 
-Note for systemd/standalone installs: the installer normalizes this setting, and the value stored in `/etc/nginx/environment` must be `1` (enabled) or `0` (disabled); any other value hand-edited into that file disables the feature.
+Note for systemd/standalone installs: the installer normalizes this setting, and the value stored in
+`/etc/nginx/environment` must be `1` (enabled) or `0` (disabled); any other value hand-edited into that file disables
+the feature.
 
 ## Usage with AWS S3 Express One Zone
+
 The gateway may be used to proxy files in the AWS S3 Express One Zone product (also called Directory Buckets).
 
-To do so, be sure that `S3_STYLE` is set to `virtual-v2`. Additionally, the `S3_SERVER` configuration must be set a combination of the bucket name and the [Zonal Endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-networking.html#s3-express-endpoints).
+To do so, be sure that `S3_STYLE` is set to `virtual-v2`. Additionally, the `S3_SERVER` configuration must be set a
+combination of the bucket name and the
+[Zonal Endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-networking.html#s3-express-endpoints).
 
 ### Directory Bucket Names
+
 See the [official documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/directory-bucket-naming-rules.html) for the most up to date rules on Directory Bucket naming.
 
 Directory Buckets must have names matching this format:
-```
+
+```text
 bucket-base-name--azid--x-s3
 ```
+
 For example:
-```
+
+```text
 bucket-base-name--usw2-az1--x-s3
 ```
+
 ### Final Configuration
+
 The bucket name must be prepended to the zonal endpoint like this
-```
+
+```text
 bucket-base-name--usw2-az1--x-s3.s3express-usw2-az1.us-west-2.amazonaws.com
 ```
+
 The above is the value that must be provided to the `S3_SERVER` variable.
 Additionally, the `S3_BUCKET_NAME` must be set to the full bucket name with the suffix:
-```
+
+```text
 bucket-base-name--usw2-az1--x-s3
 ```
+
 Buckets created in the AWS UI don't require manual specification of a suffix but it must be included in the gateway configuration.
 
 ### Trying it Out
+
 A sample Terraform script to provision a bucket is provided in `/deployments/s3_express`.
 
 ## Running as a Systemd Service
 
 An [install script](/standalone_ubuntu_oss_install.sh) for the gateway shows
-how to install NGINX from a package repository, checkout the gateway source, 
+how to install NGINX from a package repository, checkout the gateway source,
 and configure it using the supplied environment variables.
 
 To run the script copy it to your destination system, load the environment
 variables mentioned in the [configuration section](#configuration) into memory,
-and then execute the script. The script takes one optional parameter that 
+and then execute the script. The script takes one optional parameter that
 specifies the name of the branch to download files from.
 
 For example:
+
 ```shell-session
 sudo env $(cat settings.example) ./standalone_ubuntu_oss_install.sh
 ```
@@ -236,36 +288,42 @@ the project's Github [package repository](https://github.com/nginxinc/nginx-s3-g
 
 To run with the public open source image, replace the `settings` file specified
 below with a file containing your settings, and run the following command:
-```
+
+```text
 docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
     ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:latest
 ```
 
 If you would like to run with the latest njs version, run:
-```
+
+```text
 docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
     ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:latest-njs-oss
 ```
 
 Alternatively, if you would like to pin your version to a specific point in
 time release, find the version with an embedded date and run:
-```
+
+```text
 docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
     ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:latest-njs-oss-20220310
 ```
 
 #### Running Unprivileged Container Images
 
-Unprivileged container images run NGINX as a non-root user and listen on port **8080** internally (instead of port 80). This provides enhanced security by not requiring privileged ports.
+Unprivileged container images run NGINX as a non-root user and listen on port **8080** internally (instead of port 80).
+This provides enhanced security by not requiring privileged ports.
 
 To run an unprivileged image, use the `unprivileged-oss` tag and map to port **8080**:
-```
+
+```text
 docker run --env-file ./settings --publish 80:8080 --name nginx-s3-gateway \
     ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:unprivileged-oss-20250718
 ```
 
 Alternatively, you can map host port 8080 to container port 8080 to avoid requiring elevated privileges on the host:
-```
+
+```text
 docker run --env-file ./settings --publish 8080:8080 --name nginx-s3-gateway \
     ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:unprivileged-oss-20250718
 ```
@@ -276,7 +334,7 @@ The `GNUmakefile` (GNU Make 4.x) is the supported interface for building the
 gateway. To build the NGINX OSS container image, run the following from the
 project root directory:
 
-```
+```text
 make build
 ```
 
@@ -284,30 +342,36 @@ This tags the image as `nginx-s3-gateway` and `nginx-s3-gateway:oss` (the
 underlying Dockerfile is `Dockerfile.oss`). Alternatively, if you would like
 to use the latest version of [njs](https://nginx.org/en/docs/njs/), you can
 layer a build of njs from the latest source on top of the image above:
-```
+
+```text
 make build-latest-njs
 ```
 
-After building, you can run the image by issuing the following command and 
+After building, you can run the image by issuing the following command and
 replacing the path to the `settings` file with a file containing your specific
 environment variables.
-```
+
+```text
 docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
     nginx-s3-gateway:oss
 ```
 
 In the same way, if you want to use NGINX OSS container image as a non-root, unprivileged user,
 you can build it as follows:
-```
+
+```text
 make build-unprivileged
 ```
+
 And run the image binding the container port 8080 to 80 in the host like:
-```
+
+```text
 docker run --env-file ./settings --publish 80:8080 --name nginx-s3-gateway \
     nginx-s3-gateway:unprivileged-oss
 ```
 
-It is worth noting that due to the way the startup scripts work, even the unprivileged container will not work with a read-only root filesystem or a specific uid/gid set other then the default of  `101`.
+It is worth noting that due to the way the startup scripts work, even the unprivileged container will not work with a
+read-only root filesystem or a specific uid/gid set other then the default of `101`.
 
 ### Building the NGINX Plus Container Image
 
@@ -319,7 +383,7 @@ Plus Docker image repository (`docker login private-registry.nginx.com`), as
 
 To build, run the following from the project root directory:
 
-```
+```text
 make build NGINX_TYPE=plus
 ```
 
@@ -328,14 +392,16 @@ underlying Dockerfile is `Dockerfile.plus`). Alternatively, if you would like
 to use the latest version of [njs](https://nginx.org/en/docs/njs/) with NGINX
 Plus, you can layer a build of njs from the latest source on top of the image
 above:
-```
+
+```text
 make build-latest-njs NGINX_TYPE=plus
 ```
 
 After building, you can run the image by issuing the following command and
 replacing the path to the `settings` file with a file containing your specific
 environment variables.
-```
+
+```text
 docker run --env-file ./settings --publish 80:80 --name nginx-plus-s3-gateway \
     nginx-s3-gateway:plus
 ```
@@ -344,9 +410,9 @@ docker run --env-file ./settings --publish 80:80 --name nginx-plus-s3-gateway \
 
 [AWS instance profiles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile)
 allow you to assign a role to a compute so that other AWS services can trust
-the instance without having to store authentication keys in the compute 
+the instance without having to store authentication keys in the compute
 instance. This is useful for the gateway because it allows us to run the
-gateway without storing an unchanging `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and 
+gateway without storing an unchanging `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and
 `AWS_SESSION_TOKEN` in a file on disk or in an easily read environment variable.
 
 Instance profiles work by providing credentials to the instance via the
@@ -362,11 +428,11 @@ instance, if we run the gateway as a Systemd service there are no additional
 steps. We just run the install script without specifying the
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` environment variables.
 
-However, if we want to run the gateway as a container instance on that 
+However, if we want to run the gateway as a container instance on that
 EC2 instance, then we will need to run the following command using the AWS
 CLI tool to allow the metadata endpoint to be accessed from within a container.
 
-```
+```text
 aws ec2 modify-instance-metadata-options --instance-id <instance id> \
     --http-put-response-hop-limit 3 --http-endpoint enabled
 ```
@@ -396,7 +462,8 @@ modified.
   - `VpcId` - Any VPC ID on your AWS account
   - `Subnet1` - Any subnet ID that's in the VPC used above
   - `Subnet2` - Any subnet ID that's in the VPC used above
-- Run the following command to deploy the stack (this assumes you have the AWS CLI & credentials setup correctly on your host machine and you are running in the project root directory):
+- Run the following command to deploy the stack (this assumes you have the AWS CLI & credentials setup correctly on
+  your host machine and you are running in the project root directory):
 
   ```sh
   aws cloudformation create-stack \
@@ -408,26 +475,33 @@ modified.
 - Wait for the CloudFormation Stack deployment to complete
   (can take about 3-5 minutes)
   - You can query the stack status with this command:
+
     ```sh
     aws cloudformation describe-stacks \
       --stack-name nginx-s3-gateway \
       --query "Stacks[0].StackStatus"
     ```
+
 - Wait until the query above shows `"CREATE_COMPLETE"`
 - Run the following command to get the URL used to access the service:
+
   ```sh
   aws cloudformation describe-stacks \
     --stack-name nginx-s3-gateway \
     --query "Stacks[0].Outputs[0].OutputValue"
   ```
-  - Upload a file to the bucket first to prevent getting a `404` when visiting 
+
+  - Upload a file to the bucket first to prevent getting a `404` when visiting
     the URL in your browser
+
   ```sh
   # i.e.
   aws s3 cp README.md s3://<bucket_name>
   ```
+
 - View the container logs in CloudWatch from the AWS web console
 - Run the following command to delete the stack and all resources:
+
   ```sh
   aws cloudformation delete-stack \
     --stack-name nginx-s3-gateway
@@ -435,18 +509,27 @@ modified.
 
 ## Running on EKS with IAM roles for service accounts
 
-If you are planning to use the container image on an EKS cluster, you can use a [service account]((https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) which can assume a role using [AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).
+If you are planning to use the container image on an EKS cluster, you can use a
+[service account](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) which can
+assume a role using
+[AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).
 
-- Create a new [AWS IAM OIDC Provider](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html). If you are using AWS EKS Cluster, then the IAM OIDC Provider should already be created as the part of cluster creation. So validate it before you create the new IAM OIDC Provider.
+- Create a new
+  [AWS IAM OIDC Provider](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html).
+  If you are using AWS EKS Cluster, then the IAM OIDC Provider should already be created as the part of cluster
+  creation. So validate it before you create the new IAM OIDC Provider.
 - Configuring a [Kubernetes service account to assume an IAM role](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html)
 - [Annotate the Service Account](https://docs.aws.amazon.com/eks/latest/userguide/cross-account-access.html) using IAM Role create in the above step.
 - [Configure your pods, Deployments, etc to use the Service Account](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)
 - As soon as the pods/deployments are updated, you will see the couple of Env Variables listed below in the pods.
   - `AWS_ROLE_ARN` - Contains IAM Role ARN
-  - `AWS_WEB_IDENTITY_TOKEN_FILE`  - Contains the token which will be used to create temporary credentials using AWS Security Token Service.
-- You must also set the `AWS_REGION` and `JS_TRUSTED_CERT_PATH` environment variables as shown below in addition to the normal environment variables listed in the Configuration section.
+  - `AWS_WEB_IDENTITY_TOKEN_FILE` - Contains the token which will be used to create temporary credentials using AWS
+    Security Token Service.
+- You must also set the `AWS_REGION` and `JS_TRUSTED_CERT_PATH` environment variables as shown below in addition to the
+  normal environment variables listed in the Configuration section.
 
 The following is a minimal set of resources to deploy:
+
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -514,19 +597,26 @@ spec:
               port: http
 ```
 
-**Note:** If using an unprivileged container image (e.g., `unprivileged-oss-YYYYMMDD`), change `containerPort: 80` to `containerPort: 8080` as unprivileged containers listen on port 8080.
+**Note:** If using an unprivileged container image (e.g., `unprivileged-oss-YYYYMMDD`), change `containerPort: 80` to
+`containerPort: 8080` as unprivileged containers listen on port 8080.
 
 ## Running on EKS with EKS Pod Identities
 
-An alternative way to use the container image on an EKS cluster is to use a service account which can assume a role using [Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+An alternative way to use the container image on an EKS cluster is to use a service account which can assume a role
+using [Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).
+
 - Installing the [Amazon EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html) on the cluster
 - Configuring a [Kubernetes service account to assume an IAM role with EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-association.html)
 - [Configure your pods, Deployments, etc to use the Service Account](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html)
 - As soon as the pods/deployments are updated, you will see the couple of Env Variables listed below in the pods.
-  - `AWS_CONTAINER_CREDENTIALS_FULL_URI` - Contains the URI of the EKS Pod Identity Agent that will provide the credentials 
-  - `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`  - Contains the token which will be used to create temporary credentials using the EKS Pod Identity Agent.
+  - `AWS_CONTAINER_CREDENTIALS_FULL_URI` - Contains the URI of the EKS Pod Identity Agent that will provide the credentials
+  - `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` - Contains the token which will be used to create temporary credentials
+    using the EKS Pod Identity Agent.
 
-The minimal set of resources to deploy is the same than for [Running on EKS with IAM roles for service accounts](#running-on-eks-with-iam-roles-for-service-accounts), except there is no need to annotate the service account:
+The minimal set of resources to deploy is the same than for
+[Running on EKS with IAM roles for service accounts](#running-on-eks-with-iam-roles-for-service-accounts), except
+there is no need to annotate the service account:
+
 ```yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -537,7 +627,14 @@ metadata:
 ## Troubleshooting
 
 ### Disable default `404` error message
-The default behavior of the container is to return a `404` error message for any non-`200` response code. This is implemented as a security feature to sanitize any error response from the S3 bucket being proxied. For container debugging purposes, this sanitization can be turned off by commenting out the following lines within [`default.conf.template`](https://github.com/nginxinc/nginx-s3-gateway/blob/master/common/etc/nginx/templates/default.conf.template). 
+
+The default behavior of the container is to return a `404` error message for any non-`200` response code. This is
+implemented as a security feature to sanitize any error response from the S3 bucket being proxied. For container
+debugging purposes, this sanitization can be turned off by commenting out the following lines within
+[`default.conf.template`][default-conf-template].
+
+[default-conf-template]: https://github.com/nginxinc/nginx-s3-gateway/blob/master/common/etc/nginx/templates/default.conf.template
+
 ```bash
 proxy_intercept_errors on;
 error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
@@ -551,4 +648,6 @@ denied in the access phase and deliberately collapsed to the same sanitized
 `404` by the `error_page` configuration shown above.
 
 ### Error `403 Access Denied` for AWS Accounts with MFA Enabled
-The REST authentication method used in this container does not work with AWS IAM roles that have MFA enabled for authentication. Please use AWS IAM role credentials that do not have MFA enabled. 
+
+The REST authentication method used in this container does not work with AWS IAM roles that have MFA enabled for
+authentication. Please use AWS IAM role credentials that do not have MFA enabled.


### PR DESCRIPTION
### Proposed changes

The docs had no automated enforcement, unlike the shell scripts (shellcheck) and the GNUmakefile (checkmake), and had drifted to 344 lint findings. This adopts [rumdl](https://rumdl.dev) as the Markdown linter/formatter and brings every tracked `.md` file to a clean bill.

**Tooling**

- `.rumdl.toml` encodes the house style, with a comment on each non-default choice:
  - `MD013` wraps prose at **120 columns**, exempting code blocks and tables — the environment-variable table in `docs/getting_started.md` and the deliberately formatted examples must not be reflowed.
  - `MD004` pins bullets to `-`, already dominant in the tree. rumdl's default `consistent` mode instead locks in whichever marker each file happens to use first, which is how `README.md` and `docs/development.md` had diverged.
  - `MD060` aligns table pipes in source, so raw text and diffs stay legible.
  - `MD033` permits `<br>` — the only way to break a line inside a table cell.
  - `MD041` is disabled repo-wide: GitHub issue/PR templates open with a task heading, not a document `H1`. Disabling the rule beat adding a cosmetic heading to the template.
- New `make lint-md` (report) and `make fmt-md` (apply fixes); `lint-md` joins the aggregate `lint` target, and `rumdl` joins `check-tools`' optional-tool list.
- The CI `lint` job installs rumdl from npm (prebuilt binary, nothing to compile or cache), pinned via a `RUMDL_VERSION` env var so a future release can't fail the job on unchanged docs. Without this step `make lint` exits 127 on every PR.

**Documentation** — mostly mechanical: blank lines around headings and fences, languages on bare fences, trailing whitespace, long lines rewrapped. Where a single URL exceeded the limit on its own, the link became a reference-style definition instead of being split mid-token. Substantive fixes found along the way:

- Repaired a doubled-paren link (`[...]((https://...))`) to the EKS service-account docs that rendered as a broken relative link.
- Pointed the `S3_STYLE` table's anchor at the heading that actually exists (`#user-content-...` → `#choosing-a-s3_style-setting`).
- Replaced two bare `[here]` link texts with descriptive ones.
- Added alt text to the two architecture diagrams.
- Wrapped the `www.mysite.com/somepath` placeholders in code spans, so the formatter doesn't rewrite a *path* example into an autolink to a real host.

`AGENTS.md` documents the new targets and retires its "disable markdown autoformatters" rule — rumdl is now the sanctioned formatter, so its output is expected rather than reviewable churn.

No functional change to the gateway: no njs module, template, or entrypoint script is touched.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works. — n/a; the change is docs and lint tooling. `make lint-md` is itself the regression check, and it's wired into `make lint` and CI.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes. — `make lint` passes end to end (checkmake + shellcheck + rumdl). Verified `make fmt-md` is idempotent, so the code-span fixes above survive a re-format.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
