### PR TITLE
feat: add agent-driven smoke-test skill

### DIFF
--- a/.claude/skills/smoke-test/SKILL.md
+++ b/.claude/skills/smoke-test/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: smoke-test
+description: Stand up the gateway's live integration stack and run an
+  adaptive, AI-driven smoke test of all major gateway features, root-causing
+  any failure to the responsible njs module, config template, or entrypoint
+  script. Use when asked to smoke test the gateway, verify a feature against
+  a live stack, probe for regressions, or reproduce a reported gateway issue.
+---
+
+# Gateway Smoke Test
+
+Bring up the compose stack the integration suite uses (gateway + the
+S3-compatible object-store origin), probe the gateway's features with live
+HTTP requests, reconfigure the gateway between phases, root-cause every
+failure, and emit a structured findings report.
+
+Prime directive: **discover, don't assume.** The compose file, the
+GNUmakefile, and `docs/getting_started.md` are the source of truth for
+services, ports, credentials, and settings. The reference files in this
+skill pin a starting checklist; when discovery disagrees with a pinned
+value, discovery wins. Never hardcode or name the origin's implementation
+technology — describe it as "the S3-compatible origin" and derive every
+detail from the compose file.
+
+## Scope
+
+Determine what to run based on `$ARGUMENTS`:
+
+| Argument | Mode |
+|----------|------|
+| *(empty)* | Full sweep: phases P0–P7 in order, report at the end |
+| `quick` | P0 baseline + P1 content/listing only (~2 minutes) |
+| `extended` | Full sweep plus P8 credential overlays and P9 TLS origin |
+| `holes` | P0, then only probes tagged HOLE in `references/phases.md` |
+| `regressions` | P0, then every pinned set in `references/regressions.md` |
+| `issue <N>` or `#<N>` | P0, then the pinned set for issue N; if N is not pinned, read the issue with `gh issue view` and design probes from it |
+| `<area>` | P0, then the matching phase(s) — see the area map below |
+
+Area keyword → phase map: `listing`/`index` → P1; `paths` → P2;
+`signatures`/`styles` → P3; `methods`/`cors` → P4; `cache` → P5;
+`headers` → P6; `buckets`/`ipv6` → P7; `creds` → P8; `tls` → P9.
+Unrecognized argument → ask the user, don't guess.
+
+---
+
+## Step 1: Discover the environment
+
+All read-only. Do this in every mode.
+
+1. Read `test/docker-compose.yaml`. Record: the gateway service name and
+   host port mapping; the origin service name, image, internal/host ports,
+   root credentials, region, and bucket name; which gateway `environment:`
+   keys are **bare pass-through** (a bare key whose variable is unset in
+   the invoking shell reaches the container as an *empty string that
+   overrides the image's `ENV` default* — every one of these must be
+   exported explicitly); which keys use `${VAR:-default}` interpolation;
+   and which documented gateway settings have **no compose key at all**
+   (those need the overlay technique in Step 3).
+2. Run `make help` (or read the `GNUmakefile`) to confirm current target
+   names. The GNUmakefile is the only supported build/test interface.
+3. Read the environment-variable table in `docs/getting_started.md` and
+   diff it against the checklist in `references/phases.md`. Any setting in
+   the docs that no phase covers gets an improvised probe and, if it
+   misbehaves, a `coverage-gap` finding.
+4. Find the data-seeding function in `test/run_integration_tests.sh`
+   (search for the bucket name). It names the origin's CLI client command,
+   the alias/bucket setup, and the data directory (`test/data/<bucket>/`).
+   Read it — **never source or execute that script**; it runs the whole
+   suite at import time and arms exit traps.
+5. Preflight:
+   - `docker image inspect nginx-s3-gateway` — if missing, run
+     `make build`.
+   - Compare the image's `Created` timestamp against the newest commit
+     touching `common/`, `oss/`, or `Dockerfile.*`
+     (`git log -1 --format=%cI -- common oss Dockerfile.*`). If the image
+     is older, warn and run `make build`: tests against a stale image
+     probe the baked-in code, not the working tree.
+   - Check the discovered host ports. If a port is held by a container
+     from another project, **abort with a clear message**. If leftover
+     containers from this stack's compose project exist, tear them down
+     first (Step 6 teardown command).
+
+---
+
+## Step 2: Stand up and seed
+
+Substitute discovered values throughout; the commands below reflect the
+compose file at the time this skill was written.
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+export COMPOSE_COMPATIBILITY=true NGINX_INTERNAL_PORT=80
+# Every bare pass-through key gets an explicit value — never rely on shell
+# inheritance (bare key + unset var = empty string inside the container):
+export AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=false \
+  PROVIDE_INDEX_PAGE=false APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=false \
+  STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" \
+  STATIC_SITE_HOSTING="" PROXY_CACHE_BYPASS_NO_CACHE=false \
+  PROXY_CACHE_IGNORE_HEADERS="" IPV6_ENABLED=""
+docker compose -f test/docker-compose.yaml -p ngt up -d
+```
+
+Seed by replicating the discovered recipe: register a CLI alias for the
+origin using the credentials from the compose file, create the bucket
+(ignore-existing), copy every entry under `test/data/<bucket>/` into it,
+and write the runtime-generated special-character object the suite's data
+function creates. If the CLI client is not installed on the host, run its
+container image attached to the stack's network (`--network ngt_default`).
+
+Readiness gate: poll `http://localhost:8989/health` until it returns 200
+(timeout ~30 s). This also exercises the gateway's health endpoint, which
+the fixed suite never requests.
+
+Assert idioms (inline; do not source suite helpers):
+
+```bash
+# Status assert:
+curl -s -o /dev/null -w '%{http_code}' <url>
+# Log assert — capture first; piping `compose logs` into `grep -q` dies
+# with SIGPIPE under pipefail exactly when the match is found:
+logs="$(docker compose -f test/docker-compose.yaml -p ngt logs nginx-s3-gateway 2>&1)"
+grep -qF '<expected text>' <<< "$logs"
+```
+
+---
+
+## Step 3: Reconfigure between phases
+
+Recreate only the gateway; the origin and its seeded data stay up, and the
+gateway's proxy cache (container-local) resets, keeping cache phases
+deterministic:
+
+```bash
+<changed exports> docker compose -f test/docker-compose.yaml -p ngt \
+  up -d --force-recreate nginx-s3-gateway
+```
+
+For settings with **no compose pass-through key** (for example
+`DIRECTORY_LISTING_PATH_PREFIX`, `FOUR_O_FOUR_ON_EMPTY_BUCKET`,
+`HEADER_PREFIXES_TO_STRIP`, `HEADER_PREFIXES_ALLOWED`,
+`PROXY_CACHE_USE_STALE`, `CORS_ALLOW_PRIVATE_NETWORK_ACCESS`, or an
+`S3_BUCKET_NAME` override), write a minimal overlay to a scratch directory
+(session scratchpad or `mktemp -d` — never the repo) and stack it with a
+second `-f`; compose merges `environment:` maps by key:
+
+```yaml
+# <scratch>/overlay.yaml
+services:
+  nginx-s3-gateway:
+    environment:
+      FOUR_O_FOUR_ON_EMPTY_BUCKET: "true"
+```
+
+```bash
+docker compose -f test/docker-compose.yaml -f <scratch>/overlay.yaml \
+  -p ngt up -d --force-recreate nginx-s3-gateway
+```
+
+After every recreate: wait on `/health`, then check the startup banner in
+the gateway logs (`S3 Backend Environment:` block — addressing style,
+signature version, IPv6 listen state) to confirm the settings you intended
+actually took effect before probing. A probe against a misconfigured
+gateway produces phantom findings.
+
+---
+
+## Step 4: Run the phases in scope
+
+Read only the `## P<N>` sections of `references/phases.md` selected by the
+dispatch table. Phase index:
+
+| Phase | Focus |
+|-------|-------|
+| P0 | Baseline: health, startup banner, GET/HEAD, Range, 404 sanitization |
+| P1 | Directory listing, index pages, append-slash, special-char keys |
+| P2 | Path rewriting: strip/prefix leading directory path |
+| P3 | Addressing styles × signature versions |
+| P4 | Method policy (405 contract) and CORS |
+| P5 | Proxy cache: hits, bypass, ignored headers, stale serving, slices |
+| P6 | Header prefix stripping/allowlisting |
+| P7 | Empty-bucket behavior and IPv6 listen directives |
+| P8 | (extended) Credential sources: metadata-mock and secret-file overlays |
+| P9 | (extended) TLS verification of the origin |
+
+The listed probes are the floor, not the ceiling. If a response looks
+anomalous — an unexpected header, a suspicious log line, a body that is
+almost right — chase it with follow-up probes before moving on.
+
+---
+
+## Step 5: Root-cause failures
+
+On any failed probe, read `references/root-cause.md` and follow it:
+collect evidence up the ladder, localize to a component with the symptom
+table, then run the classification protocol. Record a finding for every
+failure, but do not classify a finding as `defect` until it has a minimal
+reproduction on a fresh recreate **and** has been checked against
+documented behavior, `git log`, open issues, and
+`references/regressions.md`.
+
+```text
+FINDING: <short title>
+PHASE: <P0..P9 or regression id>
+FILE: <suspected component path, or n/a>
+EVIDENCE: <probe command; expected vs actual; log/config excerpt>
+CLASSIFICATION: defect | environment | expected-behavior | coverage-gap
+SEVERITY: critical | major | minor | info
+```
+
+---
+
+## Step 6: Tear down, report, draft issues
+
+Teardown runs unconditionally — after success, failure, or abort. The
+`--profile` flag is required: the dynamic-credentials overlay adds a
+`depends_on` for a profile-gated service, and compose rejects the merged
+project as invalid without it:
+
+```bash
+docker compose --profile dynamic-credentials \
+  -f test/docker-compose.yaml \
+  -f test/docker-compose.dynamic-credentials.yaml \
+  -p ngt down --volumes --remove-orphans
+```
+
+Also remove any CLI alias you registered and delete scratch overlays,
+certificates, and secret files.
+
+Print the report in the conversation (offer to save a copy to the scratch
+directory only if asked; never write it into the repo):
+
+```text
+## Smoke Test Report: <scope> — <date>
+
+### Environment
+- Gateway image: <tag/id, created <date>>; stack: compose project ngt
+- Origin: <service name and image as discovered from the compose file>
+
+### Phase results
+| Phase | Env variant | Probes | Pass | Fail | Notes |
+|-------|-------------|--------|------|------|-------|
+
+### Findings
+<FINDING blocks, severity-ordered>
+
+### Summary
+- Phases run: N/N; probes: N (N pass, N fail)
+- Findings: N (N defect, N environment, N expected-behavior, N coverage-gap)
+- Verdict: PASS | PASS WITH FINDINGS | FAIL
+```
+
+Then, for each finding classified `defect`, draft a ready-to-file GitHub
+issue (title; body with reproduction commands, expected vs actual
+behavior, root cause, suspected component file, gateway image/commit) for
+`gh issue create --repo nginx/nginx-s3-gateway`. Present the drafts and
+file nothing without explicit per-issue user approval.
+
+---
+
+## Guardrails
+
+- Do NOT use or mention `test.sh`; the GNUmakefile is the only supported
+  build/test interface.
+- Do NOT source or execute `test/run_integration_tests.sh` — it runs the
+  entire suite at import time. Read it only.
+- Do NOT skip teardown. The Step 6 `down --volumes --remove-orphans`
+  command runs even when a phase aborts or the user interrupts.
+- Do NOT pass bare compose environment keys — export an explicit value for
+  every pass-through key, empty string only when emptiness is intended.
+- Do NOT probe a stale image. After any source edit, `make build` before
+  the next probe; retesting without a rebuild exercises the baked-in copy.
+- Do NOT run `make test-matrix` or `make test-matrix-plus` unless the user
+  explicitly asks; the smoke test is not the CI matrix.
+- Do NOT modify repository files. Overlays, certificates, and generated
+  secrets live in the scratch directory.
+- Do NOT name the origin's implementation technology in probes, findings,
+  or reports — use details discovered from the compose file.
+- Do NOT classify a finding as `defect` or draft an issue without a
+  minimal reproduction plus checks against `docs/getting_started.md`,
+  `git log`, `gh issue list --search`, and `references/regressions.md`;
+  never file an issue without the user's approval.
+- Do NOT continue when the discovered host ports are held by containers
+  from another project — abort and tell the user which ports are busy.

--- a/.claude/skills/smoke-test/references/phases.md
+++ b/.claude/skills/smoke-test/references/phases.md
@@ -1,0 +1,413 @@
+# Smoke-test phase specifications
+
+Pinned checklist as of 2026-08. Discovery (SKILL.md Step 1) wins on any
+conflict: verify fixture names against `test/data/<bucket>/`, ports and
+credentials against `test/docker-compose.yaml`, and settings against
+`docs/getting_started.md` before trusting a pinned value.
+
+Conventions used below:
+
+- `BASE` = the gateway's host URL (currently `http://localhost:8989`).
+- "recreate with X" = Step 3 of SKILL.md with the listed exports/overlay,
+  then wait on `/health` and confirm the startup banner.
+- Every phase inherits the Step 2 baseline exports unless it overrides
+  them; settings marked *(overlay)* have no compose pass-through key.
+- Tags: **HOLE** = never covered by the fixed integration suite;
+  **pin #N** = regression assertion for a fixed GitHub issue (see
+  `references/regressions.md`).
+
+---
+
+## P0: Baseline sanity
+
+Env: Step 2 defaults (v4 signatures, listing off, index off).
+
+1. `GET BASE/health` → 200. **HOLE** — the suite never requests it.
+2. Gateway logs contain the startup banner block `S3 Backend
+   Environment:` with `AWS Signatures Version: v4` and an `Addressing
+   Style:` matching the export; the secret access key value from the
+   compose file must NOT appear anywhere in the logs.
+3. `GET BASE/a.txt` → 200; body byte-identical to
+   `test/data/bucket-1/a.txt` (compare with `cmp`).
+4. `HEAD BASE/a.txt` → 200 with `Content-Length` equal to the fixture's
+   size on disk.
+5. `GET BASE/a.txt` with `Range: bytes=0-9` → 206 with a 10-byte body.
+6. `GET BASE/no-such-object` → 404; the body must be the gateway's
+   sanitized error page — it must not contain origin XML (`<Error>`,
+   request-id fields) or the bucket name.
+7. `GET BASE/b//e.txt` → 404. Double slashes are preserved as distinct
+   object-key bytes; `b//e.txt` is not `b/e.txt` (pinned suite behavior).
+8. `GET BASE/soap` → 404 (the SOAP API location is blocked).
+
+Covers: `/health` HOLE, sanitized-404 contract, double-slash pin.
+
+---
+
+## P1: Directory listing, index pages, special characters
+
+Recreate with `ALLOW_DIRECTORY_LIST=true
+APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true`.
+
+1. `GET BASE/` → 200 HTML listing; entries must match the top level of
+   `test/data/bucket-1/` read at run time (e.g. `a.txt`, `a/`, `b/`).
+2. `GET BASE/b/` → 200 listing containing `e.txt` and `c/`.
+3. `GET BASE/b` → 302 with a **relative** `Location: /b/`
+   (`absolute_redirect off`); query strings must survive the redirect
+   (`GET BASE/b?x=1` → `Location: /b/?x=1`).
+4. Percent-encoded special-character keys → 200 with correct bodies:
+   - `GET BASE/a/plus%2Bplus.txt` — and verify the *raw* form
+     `BASE/a/plus+plus.txt` also returns 200 (`+` must not decay to
+     space in the object key).
+   - the Unicode fixtures (Cyrillic/Japanese/Hebrew names under `a/`,
+     `b/`, and the Cyrillic directory), percent-encoded byte-wise.
+   - the generated `a/%@!*()=$#^&|.txt` object (encode every reserved
+     byte, e.g. `%25%40%21%2A%28%29%3D%24%23%5E%26%7C`).
+   - `системы/%bad%file%name%` — literal `%` bytes must be sent as
+     `%25`.
+5. Listing pages must link those names correctly: entry hrefs are
+   **root-relative** (`/b/c/`, percent-encoded), so resolve them against
+   `BASE` — not against the listing page's path — and expect 200. This
+   catches escaping bugs in the listing XSLT rather than in object
+   fetching.
+
+Recreate with `PROVIDE_INDEX_PAGE=true` (listing still on):
+
+6. `GET BASE/statichost/` → 200; body identical to
+   `test/data/bucket-1/statichost/index.html`.
+7. `GET BASE/statichost/noindexdir/` → directory has no `index.html`;
+   with listing on this falls back to a listing — expect 200 HTML
+   containing `noindex.html`. Recreate with `ALLOW_DIRECTORY_LIST=false
+   PROVIDE_INDEX_PAGE=true` and expect 404 instead.
+8. `GET BASE/statichost/noindexdir/multipledir/` → 200 (nested index).
+
+*(overlay)* Recreate with listing on plus
+`DIRECTORY_LISTING_PATH_PREFIX: "files/"`:
+
+9. `GET BASE/` → 200; listing hrefs are prefixed with `files/` while
+   `GET BASE/a.txt` (un-prefixed) still returns 200 — the prefix
+   rewrites only the rendered links, for gateways published behind an
+   outer path-adding proxy. **HOLE** — the suite never sets this and
+   the compose file has no key for it.
+
+Covers: listing-prefix HOLE, append-slash contract, URI-escaping surface.
+
+---
+
+## P2: Path rewriting (strip / prefix leading directory path)
+
+Recreate with `STRIP_LEADING_DIRECTORY_PATH=/tostrip`:
+
+1. `GET BASE/tostrip/a.txt` → 200, body of `a.txt`.
+2. `GET BASE/a.txt` → 200 (paths without the prefix pass through).
+3. Characterize the documented-but-surprising unanchored match:
+   `GET BASE/tostripextra/a.txt` — record actual behavior; classify as
+   `expected-behavior` unless it contradicts `docs/getting_started.md`.
+
+Recreate with `PREFIX_LEADING_DIRECTORY_PATH=/b ALLOW_DIRECTORY_LIST=true`:
+
+4. `GET BASE/e.txt` → 200 (origin key `b/e.txt`); `GET BASE/c/d.txt` →
+   200 (`b/c/d.txt`).
+5. `GET BASE/` → 200 listing whose hrefs must NOT leak the prefix: it
+   contains `c/` and `e.txt` links, no `/b/…` links, and no parent
+   (`../`) link at the root. `GET BASE/c/` → listing that DOES contain
+   the parent link. **pin #577**
+6. Recreate with the trailing-slash form `PREFIX_LEADING_DIRECTORY_PATH=/b/`
+   → probes 4–5 behave identically. **pin #576**
+
+Recreate with `STRIP_LEADING_DIRECTORY_PATH=/tostrip
+PREFIX_LEADING_DIRECTORY_PATH=/b`:
+
+7. `GET BASE/tostrip/e.txt` → 200 (strip then prefix compose).
+
+Recreate with `PREFIX_LEADING_DIRECTORY_PATH=/statichost
+PROVIDE_INDEX_PAGE=true`:
+
+8. `GET BASE/` → 200; body identical to `statichost/index.html` (the
+   index probe must not double-apply the prefix). **pin #577**
+
+Startup validation:
+
+9. Recreate with `PREFIX_LEADING_DIRECTORY_PATH="/bad'value"` → the
+   gateway container must exit; logs name the rejected character. Same
+   for a value containing `$`. Classify as `expected-behavior` when the
+   rejection is clean; a hang or a silent start is a `defect`. Restore
+   a clean environment afterwards.
+
+Covers: #577/#575/#576/#480 pins, strip/prefix composition.
+
+---
+
+## P3: Addressing styles × signature versions
+
+The suite's CI matrix runs the two virtual-host styles (`virtual`,
+`virtual-v2`) with both signature versions; path style never runs. This
+phase covers the path-style hole and cross-checks the v2 combinations.
+
+Recreate with `S3_STYLE=path AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=true`
+(**HOLE** — path style is never a matrix leg). Note: path style keeps the
+bucket out of the upstream hostname, so it also works for buckets that
+lack a virtual-host DNS alias on the compose network.
+
+1. Banner shows `Addressing Style: path`; `GET BASE/a.txt` → 200.
+2. `GET BASE/b/` → 200 listing; a Unicode key → 200.
+
+Recreate with `S3_STYLE=virtual AWS_SIGS_VERSION=2
+ALLOW_DIRECTORY_LIST=true` (cross-check, not a hole — the suite runs
+several v2 legs, including with listing, under both matrix styles):
+
+3. `GET BASE/a.txt` → 200; `GET BASE/b/` → 200 listing.
+4. Special-character keys in their **pre-normalized** (fully
+   percent-encoded) form → 200. The RAW forms (`a/plus+plus.txt`, raw
+   `!*()`) fail under v2 with a sanitized 404: v2 signs the client's
+   raw URI bytes while sending the gateway-normalized URI upstream, so
+   the origin sees SignatureDoesNotMatch (confirmed live 2026-08; v4 is
+   unaffected because it signs the normalized form). This is known open
+   issue GH-578 — do not re-report it as a new defect while it is open.
+   Probe raw forms LAST or on a fresh cache — the cache key is the
+   normalized URI, so a raw-form failure (an upstream 403, cached under
+   `PROXY_CACHE_VALID_FORBIDDEN`, 30s) masks encoded-form requests, and
+   a prior encoded-form 200 masks the raw-form failure for
+   `PROXY_CACHE_VALID_OK` (the shared-entry masking itself is GH-579).
+5. `HEAD BASE/b/` — the suite pins HEAD on a directory as 404 (an
+   origin behavior, not v2-specific); record actual status as
+   `expected-behavior`.
+
+Recreate with `S3_STYLE=virtual-v2 AWS_SIGS_VERSION=2`:
+
+6. `GET BASE/a.txt` → 200.
+
+Covers: path-style HOLE, v2 combination cross-checks.
+
+---
+
+## P4: Method policy and CORS
+
+CORS off (Step 2 defaults — the compose file interpolates
+`CORS_ENABLED:-false`):
+
+1. `OPTIONS BASE/a.txt` → 405 with `Allow: GET, HEAD` **exactly** and no
+   `Access-Control-Allow-Origin` header. **pin #574**
+2. `PUT BASE/a.txt`, `DELETE BASE/a.txt`, `POST BASE/a.txt` → 405 each.
+3. `POST BASE/gh496-does-not-exist` → 405 — the rejection happens in the
+   rewrite phase and must not depend on whether the object exists.
+4. `POST BASE/gh551-writeguard/index.html` → 404, not 405: index-page
+   paths collapse the rejection to a sanitized 404. **pin #574**
+5. `GET BASE/a.txt` with `Origin: http://smoke.example` → 200 with no
+   CORS headers.
+
+Recreate with `CORS_ENABLED=true CORS_ALLOWED_ORIGIN=http://smoke.example`:
+
+6. Preflight `OPTIONS BASE/a.txt` with `Origin: http://smoke.example`
+   and `Access-Control-Request-Method: GET` → 204;
+   `Access-Control-Allow-Origin: http://smoke.example` and
+   `Access-Control-Allow-Methods: GET, HEAD, OPTIONS`. **pin #574**
+7. `GET BASE/a.txt` with the Origin header → 200 with
+   `Access-Control-Allow-Origin` present **exactly once** (count with
+   `grep -ci`).
+8. `GET BASE/no-such-object` with the Origin header → 404 carrying the
+   ACAO header; `PUT BASE/a.txt` with it → 405 carrying ACAO exactly
+   once (error responses participate in CORS). **pin #574**
+9. Preflight from a different origin (`Origin: http://other.example`) →
+   the response still carries the **configured** value
+   (`Access-Control-Allow-Origin: http://smoke.example`). The gateway
+   never reads the request `Origin`; it emits `CORS_ALLOWED_ORIGIN`
+   verbatim and leaves mismatch enforcement to the browser — an ACAO
+   header on a wrong-origin preflight is `expected-behavior`, not a
+   defect.
+
+*(overlay)* Recreate with CORS on plus
+`CORS_ALLOW_PRIVATE_NETWORK_ACCESS: "true"`:
+
+10. Preflight with `Access-Control-Request-Private-Network: true` →
+    response has `Access-Control-Allow-Private-Network: true`; with the
+    overlay value `"false"` → header value `false`; with it unset →
+    header absent. **HOLE**
+
+Covers: #574 pins, private-network-access HOLE.
+
+---
+
+## P5: Proxy cache
+
+Cache-hit evidence technique: overwrite the object at the origin (CLI
+copy of different content) after warming, then re-request — an unchanged
+body proves the response came from the cache. The gateway's cache resets
+on every recreate, so order within each block matters.
+
+Baseline (Step 2 defaults; `PROXY_CACHE_VALID_OK` is 1h):
+
+1. Warm `GET BASE/cache-bypass/enabled.txt` → 200. Overwrite the object
+   at the origin. `GET` again → OLD body (cache hit).
+2. Same request with `Cache-Control: no-cache` → still the OLD body
+   (bypass is off by default — the header must not bust the cache).
+
+Recreate with `PROXY_CACHE_BYPASS_NO_CACHE=true`:
+
+3. Warm → overwrite at origin → `GET` with `Cache-Control: no-cache` →
+   NEW body; then `GET` without the header → NEW body (the bypass also
+   refreshed the cache entry). **pin (suite parity)**
+
+Ignored headers (**pin #566**): seed an object whose origin response
+carries `Cache-Control: private,max-age=0` — no space after the comma;
+the CLI's copy-time attribute flag breaks on it (see the suite's
+cache-ignore-headers fixtures):
+
+4. Default env: warm → overwrite → `GET` → NEW body (the origin header
+   suppressed caching).
+5. Recreate with `PROXY_CACHE_IGNORE_HEADERS="Cache-Control Expires"`:
+   warm → overwrite → `GET` → OLD body (header ignored, entry cached).
+6. Recreate with `PROXY_CACHE_IGNORE_HEADERS="X-Bogus"` → startup must
+   abort with a clear message naming the invalid field
+   (`00-check-for-required-env.sh` allowlists the fields;
+   `25-set-proxy-ignore-headers.sh` only renders the directive);
+   `expected-behavior`. Restore a clean environment.
+
+Stale serving (**HOLE** — `PROXY_CACHE_USE_STALE` has no compose key and
+no suite coverage). *(overlay)* Recreate with
+`PROXY_CACHE_VALID_OK: "5s"` so entries expire quickly:
+
+7. Warm an object; wait ~6 s; stop the origin service
+   (`docker compose … stop <origin service>`); `GET` → 200 with the
+   cached body — the default `PROXY_CACHE_USE_STALE` includes
+   `error`/`timeout`.
+8. *(overlay)* Same sequence with `PROXY_CACHE_USE_STALE: "off"` → 404,
+   not 5xx: the upstream 502 is collapsed by the sanitized-404
+   `error_page` design. The signal is the contrast with probe 7's 200.
+9. Restart the origin, wait for its healthcheck, and re-verify
+   `GET BASE/a.txt` → 200 before any later phase runs.
+
+Slice cache:
+
+10. Recreate with `TEST_PROXY_CACHE_SLICE_SIZE=10` exported: `Range:
+    bytes=0-9` on `cache-bypass/sliced.txt` → 206 (sliced upstream
+    path); then `Range: bytes=10-19` → 206 with the correct bytes
+    (each slice is fetched and cached independently). A plain `GET`
+    without a `Range` header never enters `@s3_sliced` — the njs router
+    only redirects there when `Range` is present — so it proves nothing
+    about the slice cache.
+
+Covers: #566 pin, USE_STALE HOLE, bypass contract, slice integrity.
+
+---
+
+## P6: Response header prefix stripping / allowlisting
+
+Seed a fresh object carrying user metadata (an `x-amz-meta-…` response
+header) — the origin CLI sets it via a copy-time attribute flag.
+
+1. Step 2 defaults: `GET` the object with `curl -sI` → the
+   `x-amz-meta-…` header must be ABSENT (`x-amz-` prefixed headers are
+   stripped by default) and no other `x-amz-*` headers leak.
+2. *(overlay)* `HEADER_PREFIXES_ALLOWED: "x-amz-meta-"` → the metadata
+   header IS present; other `x-amz-*` headers (request ids) remain
+   stripped. **HOLE**
+3. *(overlay)* `HEADER_PREFIXES_TO_STRIP:
+   "x-xss-;strict-transport-;content-security-"` → those origin-emitted
+   headers disappear from responses in addition to the defaults. Pick
+   only *generic* origin headers: nginx **special** headers
+   (`Server`, `Last-Modified` — dedicated fields, not list entries)
+   cannot be stripped by the njs header filter and probing them only
+   produces phantom failures (verified live 2026-08). That silent
+   limitation is itself a doc gap worth reporting. **HOLE**
+
+Covers: header-prefix HOLEs (unit-only coverage today).
+
+---
+
+## P7: Empty-bucket behavior and IPv6 listen directives
+
+Create a second, empty bucket at the origin (CLI make-bucket). Virtual
+addressing only has DNS for the seeded bucket's hostname on the compose
+network, so pair the override with path style. *(overlay)*
+`S3_BUCKET_NAME: "<empty bucket>"` plus exports `S3_STYLE=path
+ALLOW_DIRECTORY_LIST=true`:
+
+1. `GET BASE/` → 200 with the "No Files Available for Listing" page.
+2. *(overlay)* add `FOUR_O_FOUR_ON_EMPTY_BUCKET: "true"` → `GET BASE/`
+   → 404. **HOLE**
+
+IPv6 (cross-check, not a hole — the suite covers both probes via
+`integration_test_listen_directives` in `run_integration_tests.sh` and
+`test/integration/test_entrypoint_ipv6.sh`):
+
+3. With `IPV6_ENABLED` unset/empty (auto-detect): read the rendered
+   config (`docker exec <gateway container> grep -c 'listen.*\[::\]'
+   /etc/nginx/conf.d/default.conf` — the directive is indented with
+   MULTIPLE spaces, so never anchor the pattern on a single space) —
+   the `listen [::]:…` directive must be present iff the kernel
+   supports IPv6, and the startup banner's `IPv6 Listen:` line must
+   agree with the rendered state.
+4. Recreate with `IPV6_ENABLED=true`, then `IPV6_ENABLED=false`:
+   rendered directive and banner must track the setting per
+   `docs/getting_started.md`; record any disagreement.
+
+Covers: FOUR_O_FOUR HOLE, IPv6 banner/config consistency cross-check.
+
+---
+
+## P8 (extended): Credential sources
+
+Replicate the suite's two credential phases — read their functions in
+`test/run_integration_tests.sh` for the exact overlay files, profiles,
+and mock configuration; do not improvise the mock.
+
+Container-metadata mock (overlay
+`test/docker-compose.dynamic-credentials.yaml`):
+
+1. Launch with the static credential variables scrubbed from the
+   compose command line (`env -u AWS_ACCESS_KEY_ID -u
+   AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN docker compose …`) so the
+   only credential path is the mock endpoint.
+2. `GET BASE/a.txt` → 200 (credentials fetched and used); a second GET
+   → 200 without a second fetch logged (the shared-memory cache).
+3. `docker compose … exec -T nginx-s3-gateway ls /tmp/credentials.json`
+   → must NOT exist (the legacy file cache is gone). **pin #565**
+
+Secret files (overlay `test/docker-compose.secret-file-credentials.yaml`;
+secret files on the host must be readable by the worker user — see the
+suite's function for the exact permissions dance). Launch with the SAME
+`env -u` scrub as probe 1: the overlay's `AWS_*: null` keys mean
+"inherit from the shell", so any real credentials exported in the
+invoking shell would silently override the secret files and leak into
+the test gateway:
+
+4. `GET BASE/a.txt` → 200 with credentials supplied via `AWS_*_FILE`.
+5. `docker compose … exec -T nginx-s3-gateway env` → the secret VALUE
+   must not appear. **pin #573**
+6. Characterize the validation: both `AWS_SECRET_ACCESS_KEY` and
+   `AWS_SECRET_ACCESS_KEY_FILE` set (non-empty) → startup must fail
+   with a message naming the conflict; an unreadable or empty secret
+   file → startup must fail cleanly. `expected-behavior` when clean.
+
+Covers: #573/#565 pins, credential-cache behavior.
+
+---
+
+## P9 (extended): TLS verification of the origin
+
+Replicate the suite's TLS phase (`integration_test_proxy_ssl` and its
+helpers): generate a throwaway CA and an origin server certificate into
+a scratch directory, export EVERY `TEST_…` variable the compose file
+consumes (grep it for `TEST_`: `TEST_TLS_CERT_DIR`,
+`TEST_S3_SERVER_PROTO`, `TEST_S3_TRUSTED_CERT_PATH`, `TEST_S3_SERVER`,
+`TEST_S3_SERVER_PORT`, plus the origin service's certs-dir and
+healthcheck-protocol variables), and restart the origin serving HTTPS.
+Missing the healthcheck-protocol variable is fatal to the whole phase:
+the origin's healthcheck keeps probing plain HTTP, the service never
+reports healthy, and the gateway — which depends on that condition —
+never starts.
+
+1. Gateway trusting only the default CA bundle → `GET BASE/a.txt` →
+   non-200, and gateway logs contain `upstream SSL certificate verify
+   error`. **pin #565**
+2. Gateway with the throwaway CA as its trusted certificate → 200, and
+   a `Range` request → 206 (the sliced path verifies TLS too).
+3. Path-style gateway pointed at the origin's mismatch network alias
+   (set `TEST_S3_SERVER` to the alias the suite's helper uses — a name
+   the certificate does not cover) → logs contain
+   `upstream SSL certificate does not match`. **pin #565**
+4. Tear the TLS configuration down completely afterwards (certificates
+   live only in the scratch directory; unset the `TEST_…` exports and
+   recreate the origin on plain HTTP).
+
+Covers: #565 pins, TLS trust and hostname verification.

--- a/.claude/skills/smoke-test/references/regressions.md
+++ b/.claude/skills/smoke-test/references/regressions.md
@@ -1,0 +1,95 @@
+# Pinned regression assertion sets
+
+Assertion sets for fixed GitHub issues. Used two ways: the `regressions`
+and `issue <N>` dispatch modes run them directly, and the root-cause
+classification protocol checks new failures against them before calling
+anything a new defect. Probe conventions are the same as in
+`references/phases.md` (`BASE`, recreate, overlay).
+
+Each set names its fix commit; `git log <commit> -1` shows the full
+context if a probe's intent is unclear.
+
+## #577 (also #480, #575, #576) — PREFIX_LEADING_DIRECTORY_PATH hygiene
+
+Fix commit: `432d78c`. The prefix leaked into listing links and
+headings, the index-page loopback probe applied it twice, and a
+trailing-slash value produced double-slash object keys.
+
+With `PREFIX_LEADING_DIRECTORY_PATH=/b ALLOW_DIRECTORY_LIST=true`:
+
+1. `GET BASE/e.txt` → 200 (origin key `b/e.txt`).
+2. `GET BASE/` → listing links say `c/` and `e.txt` — no `/b/…` href,
+   no `../` parent link at the root, heading shows `/` not `/b`.
+3. `GET BASE/c/` → listing contains the `../` parent link.
+
+With `PREFIX_LEADING_DIRECTORY_PATH=/b/` (trailing slash): probes 1–3
+behave identically (#576).
+
+With `PREFIX_LEADING_DIRECTORY_PATH=/statichost PROVIDE_INDEX_PAGE=true`:
+
+4. `GET BASE/` → 200, body of `statichost/index.html` (no
+   double-application by the loopback probe) (#480).
+
+Startup validation:
+
+5. A value containing `'` or `$` → container exits with a message
+   naming the rejected character.
+
+## #574 — uniform non-read method rejection and the CORS contract
+
+Fix commit: `5bb75e2` (GH-496, GH-551 lineage).
+
+CORS off:
+
+1. `OPTIONS BASE/a.txt` → 405, `Allow: GET, HEAD` exactly, no
+   `Access-Control-Allow-Origin`.
+2. `POST BASE/gh496-does-not-exist` → 405 (rewrite-phase rejection —
+   must not depend on object existence).
+3. `POST BASE/gh551-writeguard/index.html` → 404 (index-page paths
+   collapse to a sanitized 404, not 405).
+
+CORS on (`CORS_ENABLED=true CORS_ALLOWED_ORIGIN=<origin>`):
+
+4. Preflight `OPTIONS` with matching `Origin` +
+   `Access-Control-Request-Method: GET` → 204 with the exact origin in
+   `Access-Control-Allow-Origin` and
+   `Access-Control-Allow-Methods: GET, HEAD, OPTIONS`.
+5. 405 and sanitized-404 responses carry `Access-Control-Allow-Origin`
+   **exactly once** (no duplicate header).
+
+## #573 — credentials from files (Docker secrets)
+
+Fix commit: `5b08afb` (GH-67). Uses the secret-file compose overlay —
+see P8 in `references/phases.md` for the setup.
+
+1. `GET BASE/a.txt` → 200 with credentials supplied only via
+   `AWS_*_FILE`.
+2. `docker compose … exec -T nginx-s3-gateway env` → the secret value
+   is absent.
+3. Both the direct variable and its `_FILE` twin set (non-empty) →
+   startup fails naming the conflict; unreadable or whitespace-only
+   secret file → startup fails cleanly.
+
+## #566 — PROXY_CACHE_IGNORE_HEADERS
+
+Fix commit: `63e54ef`. See P5 probes 4–6 in `references/phases.md`.
+
+1. Origin `Cache-Control: private, max-age=0` suppresses caching when
+   the setting is unset.
+2. `PROXY_CACHE_IGNORE_HEADERS="Cache-Control Expires"` → the same
+   response IS cached.
+3. An unknown field name → startup aborts with a message naming it.
+
+## #565 — origin TLS verification, cache key, in-memory credentials
+
+Fix commit: `251e1e1`. TLS setup per P9 in `references/phases.md`.
+
+1. Untrusted HTTPS origin → request fails and logs contain
+   `upstream SSL certificate verify error`.
+2. Hostname mismatch (path style against the origin's mismatch alias)
+   → logs contain `upstream SSL certificate does not match`.
+3. Trusted CA → 200, and a `Range` request → 206.
+4. Cache entries are shared across differing viewer `Host` headers
+   (send the same GET with two `Host:` values; the second is a hit —
+   the cache key deliberately excludes the viewer host).
+5. `/tmp/credentials.json` does not exist in the gateway container.

--- a/.claude/skills/smoke-test/references/root-cause.md
+++ b/.claude/skills/smoke-test/references/root-cause.md
@@ -1,0 +1,78 @@
+# Root-cause playbook
+
+Read this when a probe fails. Work the evidence ladder top-down (cheap
+first), localize with the symptom table, then run the classification
+protocol before recording the finding.
+
+## Evidence ladder
+
+1. **Re-run the probe with `curl -v`** (add `--raw` for byte-level body
+   issues). Capture status, every response header, and the body.
+2. **Gateway logs.** The error log goes to stdout at `info`, and the
+   test stack sets `DEBUG: "true"` in the compose file, so njs
+   `debug_log` output is already there:
+   `docker compose -f test/docker-compose.yaml -p ngt logs nginx-s3-gateway`.
+   Signature/credential debug lines are redacted to SHA-256
+   fingerprints — compare fingerprints across requests, never expect
+   raw secrets.
+3. **Startup banner** (`S3 Backend Environment:` block near the top of
+   the logs). If the banner disagrees with the settings you exported,
+   the failure is an environment-delivery problem (bare pass-through
+   key, overlay not applied), not a gateway defect.
+4. **Rendered configuration**:
+   `docker compose … exec -T nginx-s3-gateway sh -c 'cat /etc/nginx/conf.d/*.conf'`
+   plus any files under `/etc/nginx/conf.d/gateway/`. The templates in
+   `common/etc/nginx/templates/` are rendered by the entrypoint; the
+   rendered output is what nginx actually runs.
+5. **Container environment**: `docker compose … exec -T nginx-s3-gateway env`
+   — confirms what the process actually received (and, for secret-file
+   probes, what it must not have received).
+6. **Origin-side isolation.** Use the origin CLI to `ls`/`stat` the
+   object: if the origin does not have the key you expect, the failure
+   is seeding or key-mapping, not response handling. Origin container
+   logs show whether the gateway's request arrived and with what path.
+7. **Hypothesis tests.** For njs-level suspicions, run `make test-unit`
+   or invoke the in-image njs CLI directly against a module function
+   (see AGENTS.md "Unit testing rules" for the runner invocation and
+   its fixed environment). For template-level suspicions, diff the
+   rendered config against the template.
+8. **Fresh-image check.** If the working tree is newer than the image,
+   `make build` and re-run the minimal reproduction. Only a failure
+   that reproduces on a freshly built image counts against the code.
+
+## Symptom → component map
+
+| Symptom | Look at |
+|---------|---------|
+| Container exits at startup / restart loop | Entrypoint validation: `common/docker-entrypoint.d/00-check-for-required-env.sh` (required/deprecated/conflicting vars **and** the `PROXY_CACHE_IGNORE_HEADERS` field allowlist), `01-set-defaults.envsh` (style/upstream derivation). `25-set-proxy-ignore-headers.sh` only renders the directive — it validates nothing. Often an *expected* rejection — check the log message against the docs before calling it a defect. |
+| 403 with `SignatureDoesNotMatch` in origin logs | `common/etc/nginx/include/awssig4.js` / `awssig2.js`; URI escaping in `s3gateway.js` (`_escapeURIPath`, `_encodeURIComponent`); `S3_STYLE`/Host-header mismatch (`01-set-defaults.envsh`); container clock skew. |
+| Unexpected 404 | First isolate with the origin CLI (does the key exist?); then the strip/prefix rewrite and object-key/URI construction in `s3gateway.js` (`s3uri`, `s3BaseUri`, `_escapeURIPath`); then percent-encoding of raw key bytes. Remember the sanitized-404 design: many origin errors are *deliberately* collapsed to 404 by `error_page … =404` in the templates — a 404 may be masking a 403/500, so check the origin's actual response code in its logs. |
+| Wrong body or wrong headers on success | Rendered locations in `common/etc/nginx/templates/default.conf.template` and `gateway/s3_location_common.conf.template`; listing HTML issues → `common/etc/nginx/include/listing.xsl` and the XSLT params (`rootPath`, `prefixPath`). |
+| 405 / `Allow` / CORS anomalies | The `$method_not_allowed` map and `@error405` in `default.conf.template`; `gateway/cors.conf.template`; `LIMIT_METHODS_TO*` derivation in `01-set-defaults.envsh`. |
+| Redirect anomalies (append-slash, trailing slash) | `@trailslashControl`/`@trailslash` in the templates; `trailslashRedirectUri`/`_encodePathBytes` in `s3gateway.js`; `absolute_redirect off` at server scope. |
+| Cache anomalies | Rendered `proxy_cache*` directives in `default.conf.template`: the server-scope cache block and the `@s3_sliced` location each define a `proxy_cache_key` (deliberately not keyed on the viewer `Host`) that must stay in sync apart from `$slice_range`. `cache.conf.template` holds only the two `proxy_cache_path` zone declarations. |
+| Credential failures (500s, fetch errors) | `common/etc/nginx/include/awscredentials.js`; `readEnvVarOrFile` in `utils.js`; for overlay phases, whether the static-credential scrub actually removed the variables (evidence ladder step 5). |
+| TLS failures to the origin | `23-enable_s3_proxy_ssl.sh` output (`gateway/s3_proxy_ssl.conf`), the trusted-cert path mount, and the exact nginx error line (`verify error` vs `does not match` distinguish trust from hostname). |
+
+## Classification protocol
+
+Every failed probe becomes a FINDING (format in SKILL.md Step 5). It may
+be classified `defect` only after ALL of:
+
+1. **Minimal reproduction** — a fresh gateway recreate plus the fewest
+   requests that show the failure, reproduced twice.
+2. **Not documented behavior** — the settings table and prose in
+   `docs/getting_started.md` (and code comments at the suspect site) do
+   not describe the observed behavior as intended.
+3. **Not already known** — no match in `references/regressions.md`,
+   `git log --oneline -S '<relevant symbol>'`, or
+   `gh issue list --repo nginx/nginx-s3-gateway --search '<keywords>'`
+   (check open AND recently closed issues).
+4. **Reproduces on a fresh image** when the working tree is newer than
+   the tested image.
+
+Anything that fails a gate is classified accordingly: `environment`
+(stack, seeding, ports, stale image, overlay not applied),
+`expected-behavior` (documented or deliberately validated), or
+`coverage-gap` (behavior is fine but nothing in the fixed suite would
+catch its regression — worth reporting so a test can be added).

--- a/.gitignore
+++ b/.gitignore
@@ -388,3 +388,6 @@ override.tf.json
 terraform.rc
 .tfplan
 # End of https://www.toptal.com/developers/gitignore/api/terraform
+
+# Local (per-developer) Claude Code settings inside the committed skill dir
+.claude/settings.local.json

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -4,8 +4,9 @@
 # (report) and `make fmt-md` (apply fixes).
 
 [global]
-# .opencode/ holds the local rule digests (kept verbatim, mirrored to .claude
-# via symlink); node_modules is dependency noise.
+# .claude/ holds agent skills (deliberately formatted probe tables and
+# command examples that must not be reflowed) plus per-developer tool state;
+# .opencode is a local mirror of it; node_modules is dependency noise.
 exclude = [".opencode", ".claude", "node_modules"]
 
 # GitHub issue/PR templates conventionally open with a task-oriented heading

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,11 @@ Notes:
   (transitional flag fork while njs migrates its CLI).
 - NGINX Plus builds/tests require repo certs in `plus/etc/ssl/nginx/` and a
   `license.jwt` — skip Plus targets if you don't have them.
+- An agent-driven smoke-test skill lives at `.claude/skills/smoke-test/` — it
+  stands up the integration stack from `test/docker-compose.yaml`, probes every
+  major gateway feature live, and root-causes failures. See its `SKILL.md` for
+  invocation modes (full sweep, `quick`, `holes`, `regressions`, `issue <N>`,
+  or a feature area).
 
 ## JavaScript rules (njs, not Node.js)
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -106,6 +106,10 @@ Other useful targets:
 
 Run `make help` for the full target list.
 
+Agent users can also run an adaptive live smoke test of the gateway via the
+skill in `.claude/skills/smoke-test/`, which exercises features the fixed
+integration matrix does not cover.
+
 ### Adding tests
 
 Unit tests live in `test/unit/` and run under the njs CLI inside the built


### PR DESCRIPTION
### Proposed changes

Adds an agent-driven smoke-test skill at `.claude/skills/smoke-test/` for
coding agents (Claude Code and compatible tooling). Invoked as
`/smoke-test [mode]`, it stands up the integration stack from
`test/docker-compose.yaml`, adaptively probes every major gateway feature
with live HTTP requests — including settings the fixed integration matrix
never exercises (`DIRECTORY_LISTING_PATH_PREFIX`,
`FOUR_O_FOUR_ON_EMPTY_BUCKET`, `HEADER_PREFIXES_TO_STRIP/ALLOWED`,
`PROXY_CACHE_USE_STALE`, `CORS_ALLOW_PRIVATE_NETWORK_ACCESS`,
`S3_STYLE=path`, `/health`) — root-causes failures to the responsible njs
module, config template, or entrypoint script, and reports classified
findings with drafted GitHub issues for confirmed defects.

Layout:

- `SKILL.md` — argument dispatch (full sweep, `quick`, `extended`,
  `holes`, `regressions`, `issue <N>`, feature areas), environment
  discovery/lifecycle, report format, guardrails.
- `references/phases.md` — per-phase probe specs (P0–P9) with expected
  results, tagged with coverage holes and regression pins.
- `references/root-cause.md` — evidence ladder, symptom→component map,
  and a defect-classification protocol (minimal repro + docs +
  known-issue checks before anything is called a defect).
- `references/regressions.md` — pinned assertion sets for recently fixed
  issues (#565, #566, #573, #574, #577).

The skill discovers services, ports, credentials, and settings from the
compose file, the GNUmakefile, and `docs/getting_started.md` at run time
rather than hardcoding them, so it stays correct as the repo evolves and
is agnostic to the object-store backend used by the test stack.

Supporting changes: AGENTS.md and `docs/development.md` gain pointers to
the skill; `.gitignore` covers `.claude/settings.local.json` (local
per-developer state); the `.rumdl.toml` exclusion comment is updated to
match the committed layout.

Verified by running the skill against the live stack end-to-end: a
`quick`-mode dry run plus a full P0–P7 sweep (66 probes). The sweep
found two real issues now tracked separately — #578 (SigV2 signs the raw
client URI while proxying the normalized URI) and #579 (cached upstream
403s shared across encoding variants) — which the phase specs reference
as known issues so future runs do not re-report them.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works (verified live: quick-mode dry run and a full P0–P7 sweep against the integration stack).
- [x] If applicable, I have checked that any relevant tests pass after adding my changes (`make lint` green; markdown-only change, no gateway code touched).
- [x] I have updated any relevant documentation (AGENTS.md, `docs/development.md`).
