### PR TITLE
ci: add S3_STYLE=path to the test matrix

### DIFF
--- a/.claude/skills/smoke-test/references/phases.md
+++ b/.claude/skills/smoke-test/references/phases.md
@@ -139,21 +139,23 @@ Covers: #577/#575/#576/#480 pins, strip/prefix composition.
 
 ## P3: Addressing styles × signature versions
 
-The suite's CI matrix runs the two virtual-host styles (`virtual`,
-`virtual-v2`) with both signature versions; path style never runs. This
-phase covers the path-style hole and cross-checks the v2 combinations.
+The suite's CI matrix runs all three addressing styles (`virtual`,
+`virtual-v2`, `path`) with both signature versions. This phase
+cross-checks the style/signature combinations most likely to regress.
 
 Recreate with `S3_STYLE=path AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=true`
-(**HOLE** — path style is never a matrix leg). Note: path style keeps the
-bucket out of the upstream hostname, so it also works for buckets that
-lack a virtual-host DNS alias on the compose network.
+(cross-check, not a hole — path style is now a matrix leg; issue #581
+tracks the gap it closed). The path + v2 combination is not probed in this
+phase; regressions.md item 7 covers it. Note: path style keeps the bucket
+out of the upstream hostname, so it also works for buckets that lack a
+virtual-host DNS alias on the compose network.
 
 1. Banner shows `Addressing Style: path`; `GET BASE/a.txt` → 200.
 2. `GET BASE/b/` → 200 listing; a Unicode key → 200.
 
 Recreate with `S3_STYLE=virtual AWS_SIGS_VERSION=2
 ALLOW_DIRECTORY_LIST=true` (cross-check, not a hole — the suite runs
-several v2 legs, including with listing, under both matrix styles):
+several v2 legs, including with listing, under every matrix style):
 
 3. `GET BASE/a.txt` → 200; `GET BASE/b/` → 200 listing.
 4. Special-character keys → 200 in BOTH the pre-normalized (fully
@@ -177,7 +179,8 @@ Recreate with `S3_STYLE=virtual-v2 AWS_SIGS_VERSION=2`:
 
 6. `GET BASE/a.txt` → 200.
 
-Covers: path-style HOLE, v2 combination cross-checks, #578 pin.
+Covers: addressing-style cross-checks, v2 combination cross-checks,
+#578 pin.
 
 ---
 

--- a/.claude/skills/smoke-test/references/regressions.md
+++ b/.claude/skills/smoke-test/references/regressions.md
@@ -32,7 +32,7 @@ forms first:
    excludes the delimiter/prefix listing parameters).
 
 With `S3_STYLE=path AWS_SIGS_VERSION=2 ALLOW_DIRECTORY_LIST=true`
-(fresh recreate; not a CI matrix leg — #581):
+(fresh recreate; now a CI matrix leg — #581):
 
 7. `GET BASE/a/plus+plus.txt` → 200 and `GET BASE/` → 200 listing
    (the signed listing resource is now the spec-correct `/<bucket>`,

--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -28,7 +28,7 @@ concurrency:
 #   │ Lint │
 #   └──────┘
 #   ┌────────────────────────────────────────┐
-#   │ Test OSS  (matrix: virtual, virtual-v2)├──┐
+#   │ Test OSS  (virtual, virtual-v2, path)  ├──┐
 #   └────────────────────────────────────────┘  │
 #   ┌────────────────────────────────────────┐  │  ┌──────────────────────────┐
 #   │ Test OSS + latest njs                  ├──┼─►│ Tag and push (main only) │
@@ -94,12 +94,12 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
-      # Report both addressing styles instead of cancelling the second one as
+      # Report all three addressing styles instead of cancelling the others as
       # soon as the first fails; they exercise different signing paths and the
       # legs run concurrently, so nothing is saved by stopping early.
       fail-fast: false
       matrix:
-        path_style: [virtual, virtual-v2]
+        s3_style: [virtual, virtual-v2, path]
     steps:
       - name: Check out the codebase
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/install-mc
 
       - name: Build and test - stable njs version
-        run: make test NGINX_TYPE=oss S3_STYLE=${{ matrix.path_style }}
+        run: make test NGINX_TYPE=oss S3_STYLE=${{ matrix.s3_style }}
 
   test-latest-njs:
     name: Test NGINX OSS image using latest njs commit
@@ -121,8 +121,10 @@ jobs:
       - name: Install MinIO Client
         uses: ./.github/actions/install-mc
 
+      # S3_STYLE is pinned the same way the local test-matrix target pins it,
+      # so a change to the GNUmakefile default cannot silently repoint this job.
       - name: Build and test - latest njs version
-        run: make test-latest-njs NGINX_TYPE=oss
+        run: make test-latest-njs NGINX_TYPE=oss S3_STYLE=virtual-v2
 
   test-unprivileged:
     name: Test NGINX OSS unprivileged image
@@ -135,8 +137,10 @@ jobs:
       - name: Install MinIO Client
         uses: ./.github/actions/install-mc
 
+      # S3_STYLE is pinned the same way the local test-matrix target pins it,
+      # so a change to the GNUmakefile default cannot silently repoint this job.
       - name: Build and test - unprivileged
-        run: make test-unprivileged NGINX_TYPE=oss
+        run: make test-unprivileged NGINX_TYPE=oss S3_STYLE=virtual-v2
 
 
 # Publishing (main only). Multi-architecture images go to both Docker Hub and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,8 +53,8 @@ Notes:
   (rebuilds first); `make retest` would test the stale copy.
 - Integration tests spin up MinIO via `test/docker-compose.yaml` (compose
   project `ngt`) and hit the gateway on `localhost:8989`.
-- `S3_STYLE` (`virtual` or `virtual-v2`) selects the S3 addressing style under
-  test; CI runs both.
+- `S3_STYLE` (`virtual`, `virtual-v2`, or `path`) selects the S3 addressing
+  style under test; CI runs all three.
 - The `latest-njs` variant runs the njs CLI with `-m` instead of `-t module`
   (transitional flag fork while njs migrates its CLI).
 - NGINX Plus builds/tests require repo certs in `plus/etc/ssl/nginx/` and a

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,8 @@ DOCKER            ?= docker
 # NGINX flavor to build and test: oss or plus
 NGINX_TYPE        ?= oss
 
-# S3 addressing style exercised by the integration tests: virtual or virtual-v2
+# S3 addressing style exercised by the integration tests: virtual, virtual-v2,
+# or path
 S3_STYLE          ?= virtual-v2
 
 # Output directory for generated JSDoc documentation
@@ -70,7 +71,7 @@ SHELL_SCRIPTS     := test.sh \
 SHELLCHECK_EXCLUDES := SC2027,SC2034,SC2068,SC2140
 
 # Single line on purpose: checkmake's parser does not follow continuations
-.PHONY: help check-tools check-nginx-type check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck lint-md fmt-md hadolint docs docs-open jsdoc clean clean-images all ci
+.PHONY: help check-tools check-nginx-type check-s3-style check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck lint-md fmt-md hadolint docs docs-open jsdoc clean clean-images all ci
 
 ##@ Help
 
@@ -111,6 +112,19 @@ check-nginx-type:
 	@case "$(NGINX_TYPE)" in \
 		oss|plus) ;; \
 		*) echo "ERROR: Invalid NGINX_TYPE '$(NGINX_TYPE)' - must be 'oss' or 'plus'"; exit 2;; \
+	esac
+
+# Internal: validate S3_STYLE where the test harness consumes it, mirroring
+# check-nginx-type. Every downstream consumer fails open - an unrecognized
+# style silently selects virtual-style addressing (01-set-defaults.envsh,
+# s3gateway.js) - so a typo here or in the CI matrix would otherwise produce
+# a green run that tested the wrong style. Harness-only: the runtime image
+# additionally accepts 'default' (see docs/getting_started.md), which the
+# test suite never uses.
+check-s3-style:
+	@case "$(S3_STYLE)" in \
+		virtual|virtual-v2|path) ;; \
+		*) echo "ERROR: Invalid S3_STYLE '$(S3_STYLE)' - must be 'virtual', 'virtual-v2' or 'path'"; exit 2;; \
 	esac
 
 # Internal: fail fast with actionable errors when NGINX Plus credentials are absent
@@ -175,9 +189,13 @@ test-unprivileged: build-unprivileged ## Build the unprivileged variant then tes
 # S3_STYLE and NGINX_TYPE are passed as explicit sub-make arguments (not env
 # prefixes) so they take precedence over command-line variables a user passed
 # to this invocation, which would otherwise leak into sub-makes via MAKEFLAGS.
-test-matrix: build ## Reproduce the CI matrix locally: NGINX_TYPE x {virtual,virtual-v2} + latest-njs + unprivileged
+# The retest legs must stay ahead of the variant legs: test-latest-njs and
+# test-unprivileged retag the floating image, which retest's NONVARIANT_GUARD
+# then rejects.
+test-matrix: build ## Reproduce the CI matrix locally: {virtual,virtual-v2,path} + latest-njs + unprivileged
 	$(MAKE) retest NGINX_TYPE=$(NGINX_TYPE) S3_STYLE=virtual
 	$(MAKE) retest NGINX_TYPE=$(NGINX_TYPE) S3_STYLE=virtual-v2
+	$(MAKE) retest NGINX_TYPE=$(NGINX_TYPE) S3_STYLE=path
 	$(MAKE) test-latest-njs NGINX_TYPE=$(NGINX_TYPE) S3_STYLE=virtual-v2
 	$(MAKE) test-unprivileged NGINX_TYPE=$(NGINX_TYPE) S3_STYLE=virtual-v2
 	@echo "$(NGINX_TYPE) test matrix passed"
@@ -214,14 +232,14 @@ test-unit: ## Run only the njs unit tests against the currently tagged image
 	$(call NONVARIANT_GUARD,latest-njs)
 	$(RUN_UNIT_TESTS)
 
-test-integration: check-nginx-type check-tools ## Run only the integration suite against the currently tagged image
+test-integration: check-nginx-type check-s3-style check-tools ## Run only the integration suite against the currently tagged image
 	$(call NONVARIANT_GUARD,unprivileged)
 	$(RUN_INTEGRATION_TESTS)
 
 # check-tools fails fast on a missing integration dependency (mc, curl,
 # compose, md5sum) before the unit suite spends a minute in docker, matching
 # the up-front dependency checks the legacy test.sh ran at startup.
-retest: check-nginx-type check-tools ## Test the currently tagged image without rebuilding
+retest: check-nginx-type check-s3-style check-tools ## Test the currently tagged image without rebuilding
 	$(call NONVARIANT_GUARD,latest-njs)
 	$(call NONVARIANT_GUARD,unprivileged)
 	$(RUN_UNIT_TESTS)
@@ -235,12 +253,12 @@ VARIANT_GUARD = @variant_id="$$($(DOCKER) image inspect -f '{{.Id}}' $(IMAGE_NAM
 	{ [ -n "$$variant_id" ] && [ "$$floating_id" = "$$variant_id" ]; } || { \
 	echo "ERROR: '$(IMAGE_NAME)' is not the $(1)-$(NGINX_TYPE) variant image; run 'make build-$(1)' (or 'make test-$(1)') first"; exit 2; }
 
-retest-latest-njs: check-nginx-type check-tools ## Test the current image with latest-njs semantics, no rebuild
+retest-latest-njs: check-nginx-type check-s3-style check-tools ## Test the current image with latest-njs semantics, no rebuild
 	$(call VARIANT_GUARD,latest-njs)
 	NJS_LATEST=1 $(RUN_UNIT_TESTS)
 	$(RUN_INTEGRATION_TESTS)
 
-retest-unprivileged: check-nginx-type check-tools ## Test the current image in unprivileged mode, no rebuild
+retest-unprivileged: check-nginx-type check-s3-style check-tools ## Test the current image in unprivileged mode, no rebuild
 	$(call VARIANT_GUARD,unprivileged)
 	$(RUN_UNIT_TESTS)
 	UNPRIVILEGED=1 $(RUN_INTEGRATION_TESTS)

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,6 +102,8 @@ Other useful targets:
 - `make test-latest-njs` / `make test-unprivileged` — build and test the
   image variants.
 - `make test-matrix` — reproduce the CI matrix locally.
+- `make test S3_STYLE=path` (or `virtual` / `virtual-v2`) — reproduce a single
+  CI matrix leg; plain `make test` covers only the default `virtual-v2` style.
 - `make lint` — run the linters (checkmake + shellcheck).
 
 Run `make help` for the full target list.

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -94,6 +94,23 @@ if ! { [ "${UNPRIVILEGED}" == "0" ] || [ "${UNPRIVILEGED}" == "1" ]; }; then
   exit ${no_dep_exit_code}
 fi
 
+# Validate S3_STYLE when set: every downstream consumer fails open - an
+# unrecognized value silently selects virtual-style addressing, and an empty
+# one (e.g. from a broken workflow expression) falls to the compose file's
+# virtual-v2 default - so the suite would pass while testing the wrong style.
+# Unset is fine - the compose file supplies the virtual-v2 default. Harness-only check: the runtime image additionally
+# accepts 'default' (see docs/getting_started.md), which the suite never
+# uses, so do not hoist this into the entrypoint scripts.
+if [ -n "${S3_STYLE+x}" ]; then
+  case "${S3_STYLE}" in
+    virtual|virtual-v2|path) ;;
+    *)
+      e "Invalid S3_STYLE value: '${S3_STYLE}' - must be 'virtual', 'virtual-v2' or 'path'"
+      exit ${no_dep_exit_code}
+      ;;
+  esac
+fi
+
 # The unprivileged image rewrites 'listen 80;' to 'listen 8080;' at build
 # time (Dockerfile.unprivileged); every listen-related assertion keys off
 # this single value.


### PR DESCRIPTION
### Proposed changes

Fixes #581.

No CI leg ever ran `S3_STYLE=path` under either signature version: the `test-oss` matrix covered only the two
virtual-host styles, and the v2/v4 signature matrix lives inside `test/run_integration_tests.sh`. The fix for #578
changed the SigV2 CanonicalizedResource for path-style directory listings (`/bucket` instead of `/bucket/`), so a
regression in that code path — path + v2 + listing — would have landed silently.

**Workflow** (`.github/workflows/s3-gateway.yml`):

- Matrix is now `s3_style: [virtual, virtual-v2, path]`. The key is renamed from `path_style` (a tautology once
  `path` is a value) to match the variable it feeds. Check contexts derive from the matrix *value* only — verified
  against a live run's job names — so no required status check is affected by the rename.
- The two variant jobs pin `S3_STYLE=virtual-v2` explicitly, matching the local `test-matrix` target, so a future
  change to the GNUmakefile default cannot silently repoint them.

**Local parity** (`GNUmakefile`, `test/run_integration_tests.sh`):

- `make test-matrix` (and therefore `make ci`) gains the matching `S3_STYLE=path` leg, kept ahead of the variant
  legs (which retag the floating image that `retest`'s `NONVARIANT_GUARD` checks — now documented in the recipe).
- New `check-s3-style` guard mirroring `check-nginx-type`, plus a matching check in the integration runner. Every
  downstream `S3_STYLE` consumer fails open (an unrecognized value silently selects virtual-style addressing in
  `01-set-defaults.envsh` and `s3gateway.js`; an empty one falls to the compose default), so a typo'd matrix value
  would otherwise produce a green run that tested the wrong style — the exact failure mode this PR closes.
  Deliberately harness-only: the runtime image additionally accepts `default`.

**Docs**: `AGENTS.md` and `docs/development.md` name all three styles (with a single-leg reproduction command,
`make test S3_STYLE=path`); the smoke-test skill references drop the path-style HOLE tag now that the leg is covered.

**Cost**: one more full `make test` job per workflow run (same runtime as an existing leg), and one more surface for
an unrelated CI flake per run; `fail-fast: false` keeps the legs independent.

**Follow-up after this lands on `main`** (repo settings, not part of this PR): add the new `Test NGINX OSS image
(path)` context to ruleset 6399203's required status checks so the leg gates merges — `publish-base` has
`needs: [test-oss]`, so an advisory red leg that merges would otherwise surface as a publish blockage on `main`.
Adding the context before the workflow change is on `main` would leave every open PR waiting on a check that does
not exist on its base.

Verified locally:

- `make lint` (checkmake + shellcheck + rumdl) passes.
- `make test S3_STYLE=path NGINX_TYPE=oss` — the exact command the new leg runs — exits 0 across all 16 integration
  configurations, and a rerun after the harness guard was added is equally green.
- A targeted path + v2 + listing recreate on a cold cache: raw-encoding probes and the root listing all return 200
  with zero `SignatureDoesNotMatch` in the gateway log.
- The guard rejects an invalid style (`S3_STYLE=paht` → exit 2) and accepts all three valid ones.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).