### PR TITLE
fix: collapse duplicate literal slashes in request paths (#88)

### DIFF
--- a/.claude/skills/smoke-test/references/phases.md
+++ b/.claude/skills/smoke-test/references/phases.md
@@ -35,11 +35,14 @@ Env: Step 2 defaults (v4 signatures, listing off, index off).
 6. `GET BASE/no-such-object` → 404; the body must be the gateway's
    sanitized error page — it must not contain origin XML (`<Error>`,
    request-id fields) or the bucket name.
-7. `GET BASE/b//e.txt` → 404. Double slashes are preserved as distinct
-   object-key bytes; `b//e.txt` is not `b/e.txt` (pinned suite behavior).
+7. `GET BASE/b//e.txt` → 200 with the body of `test/data/bucket-1/b/e.txt`:
+   runs of duplicate literal slashes collapse before signing and proxying
+   (pin #88). `GET BASE/b/%2Fe.txt` → 404 — a percent-encoded slash is
+   object-key data, never collapsed, and must not alias the `b/e.txt`
+   cache entry.
 8. `GET BASE/soap` → 404 (the SOAP API location is blocked).
 
-Covers: `/health` HOLE, sanitized-404 contract, double-slash pin.
+Covers: `/health` HOLE, sanitized-404 contract, #88 double-slash pin.
 
 ---
 

--- a/.claude/skills/smoke-test/references/regressions.md
+++ b/.claude/skills/smoke-test/references/regressions.md
@@ -9,6 +9,48 @@ anything a new defect. Probe conventions are the same as in
 Each set names its fix commit; `git log <commit> -1` shows the full
 context if a probe's intent is unclear.
 
+## #88 — duplicate literal slashes collapse before signing and proxying
+
+Fix commit: the commit that added this entry. The raw `$request_uri`
+bytes flowed into the S3 key and the ListObjectsV2 prefix, so a `//` in
+a request path could only match a key literally containing consecutive
+slashes and everything else surfaced as a sanitized 404 or an empty
+listing.
+
+Step 2 defaults (listing off, index off), fresh recreate (slash
+spellings share one cache entry keyed on the normalized `$s3uri` —
+probe raw forms first, same masking caveat as #578):
+
+1. `GET BASE/b//e.txt` → 200, body of `b/e.txt`;
+   `GET BASE/b//c///d.txt` → 200, body of `b/c/d.txt`.
+2. `GET BASE/b/%2Fe.txt` → 404 (a percent-encoded slash is object-key
+   data, never collapsed — the escape hatch for keys containing `//`).
+3. `GET BASE//` → 404 — the collapsed root must hit `redirectToS3`'s
+   root guard, never proxy a signed bucket-root GET (an object-listing
+   leak while listing is disabled).
+
+With `ALLOW_DIRECTORY_LIST=true`:
+
+4. `GET BASE/b//c///` → 200 listing with heading `Index of /b/c/` and
+   an `href="/b/c/d.txt"` entry (the v4 signer derives the listing
+   params from an independent read of the path, so the signed and
+   proxied prefixes must both be the collapsed form).
+5. `GET BASE//` → 200 root listing.
+
+With `AWS_SIGS_VERSION=2 ALLOW_DIRECTORY_LIST=true` (fresh recreate):
+
+6. Probes 1 and 4 again — v2 signs the `s3uri()`-derived resource, so
+   the collapsed form must authenticate; logs contain zero
+   `SignatureDoesNotMatch` occurrences.
+
+With `STRIP_LEADING_DIRECTORY_PATH=/my-bucket` (fresh recreate):
+
+7. `GET BASE//my-bucket//a.txt` → 200, body of `test/data/bucket-1/a.txt`.
+   The collapse runs before the STRIP/PREFIX map chooses its rewrite arm
+   (`$uri_full_path` is js_set-derived and pre-collapsed), so a doubled
+   slash at the stripped prefix cannot bypass the strip and address the
+   unstripped S3 key.
+
 ## #578 — SigV2 signs the same normalized URI it proxies
 
 Fix commit: the commit that added this entry (PR #582). The v2 signer

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -96,10 +96,16 @@ const SERVICE = process.env['S3_SERVICE'] || "s3";
  * @param r {NginxHTTPRequest} HTTP request
  */
 function editHeaders(r) {
+    // Classify on the raw path: only a literal trailing slash routes as a
+    // directory (redirectToS3/s3uri), while a trailing %2F is object-key
+    // data proxied as an object request (GH-88's escape hatch) - decoding
+    // here would strip the object response's headers as if it were a
+    // listing. Duplicate literal slashes need no collapsing for this
+    // check: collapsing never changes the final character.
     const isDirectoryHeadRequest =
         ALLOW_LISTING &&
         r.method === 'HEAD' &&
-        _isDirectory(decodeURIComponent(r.variables.uri_path));
+        _isDirectory(r.variables.uri_path);
 
     /* Strips all x-amz- (if x-amz- is not in ADDITIONAL_HEADER_PREFIXES_ALLOWED) headers from the output HTTP headers so that the
      * requesters to the gateway will not know you are proxying S3. */
@@ -280,9 +286,15 @@ function _s3ReqParamsForSigV2(r, bucket) {
  */
 function _s3ReqParamsForSigV4(r, bucket, host) {
     const baseUri = s3BaseUri(r);
+    /* Collapse duplicate slashes exactly as s3uri() does: the listing
+     * queryParams signed here must be derived from the same normalized
+     * path that s3uri() turns into the proxied prefix, or the signature
+     * diverges from the proxied request (GH-88; the same
+     * signed-equals-proxied invariant as GH-578). */
+    const uriPath = _collapseDuplicateSlashes(r.variables.uri_path);
     const computed_url = !utils.parseBoolean(r.variables.forIndexPage)
-        ? r.variables.uri_path
-        : r.variables.uri_path + INDEX_PAGE;
+        ? uriPath
+        : uriPath + INDEX_PAGE;
     const queryParams = _s3DirQueryParams(computed_url, r.method);
     let uri;
     if (queryParams.length > 0) {
@@ -329,6 +341,30 @@ function s3BaseUri(r) {
 }
 
 /**
+ * Builds the value of the $uri_full_path variable: the client-facing request
+ * path, i.e. $request_uri with the query string removed and runs of
+ * duplicate literal slashes collapsed (GH-88). The collapse must happen
+ * here, before the STRIP/PREFIX_LEADING_DIRECTORY_PATH map derives
+ * $uri_path from this variable, so that every duplicate-slash spelling of a
+ * path takes the same strip/prefix rewrite arm as its canonical spelling -
+ * an uncollapsed '//stripped-prefix/...' would fail the map's anchored
+ * regex and bypass the strip entirely. The rewrite can itself join a '//'
+ * back into $uri_path (a PREFIX value with a trailing slash), so s3uri()
+ * and the signers still collapse the paths they read.
+ *
+ * @param r {NginxHTTPRequest} HTTP request object
+ * @returns {string} query-stripped, slash-collapsed client-facing path
+ */
+function uriFullPath(r) {
+    const requestUri = r.variables.request_uri;
+    const queryIdx = requestUri.indexOf('?');
+    const path = queryIdx === -1
+        ? requestUri
+        : requestUri.substring(0, queryIdx);
+    return _collapseDuplicateSlashes(path);
+}
+
+/**
  * Returns the s3 path given the incoming request
  *
  * @param r {NginxHTTPRequest} HTTP request
@@ -340,6 +376,10 @@ function s3BaseUri(r) {
  *   path ($uri_full_path) instead of the rewritten $uri_path, because the
  *   gateway re-applies the STRIP/PREFIX_LEADING_DIRECTORY_PATH rewrite to
  *   every incoming request (GH-575).
+ *
+ * Runs of duplicate literal slashes in the request path are collapsed
+ * before the URI is built (GH-88); percent-encoded slashes (%2F) are
+ * preserved as object-key data.
  * @returns {string} uri for s3 request
  */
 function s3uri(r, opts) {
@@ -360,10 +400,10 @@ function s3uri(r, opts) {
         // structurally - a probe must never become a "?delimiter=..."
         // listing URI.
         basePath = '';
-        uriPath = r.variables.uri_full_path;
+        uriPath = _collapseDuplicateSlashes(r.variables.uri_full_path);
     } else {
         basePath = s3BaseUri(r);
-        uriPath = r.variables.uri_path;
+        uriPath = _collapseDuplicateSlashes(r.variables.uri_path);
     }
 
     // Create query parameters only if directory listing is enabled.
@@ -436,7 +476,12 @@ function redirectToS3(r) {
         return;
     }
 
-    const uriPath = r.variables.uri_path;
+    /* Route on the same normalized path that s3uri() will proxy. In
+     * particular 'GET //' must collapse to '/' and hit the root guard
+     * below - uncollapsed it would bypass the uriPath === "/" check and
+     * proxy a signed bucket-root GET upstream, leaking an object listing
+     * while directory listing is disabled (GH-88). */
+    const uriPath = _collapseDuplicateSlashes(r.variables.uri_path);
     const isDirectoryListing = ALLOW_LISTING && _isDirectory(uriPath);
 
     if (isDirectoryListing && (r.method === 'GET' || r.method === 'HEAD')) {
@@ -476,8 +521,11 @@ function trailslashControl(r) {
         // on sequences nginx accepts (e.g. invalid UTF-8 such as %C3) and
         // then misclassify any encoded dots elsewhere in the same path.
         // Unlike $uri, the result is deliberately not normalized
-        // (dot-segments and duplicate slashes are kept) - the decoded path
-        // is used for classification only, never emitted in the redirect.
+        // (dot-segments and duplicate slashes are kept - collapsing cannot
+        // change the trailing-slash or final-segment-extension
+        // classification, and s3uri()/the signers collapse duplicate
+        // slashes themselves per GH-88) - the decoded path is used for
+        // classification only, never emitted in the redirect.
         if (path.indexOf('%') !== -1) {
             path = path.replace(/%([0-9A-Fa-f]{2})/g, function (_match, hex) {
                 return String.fromCharCode(parseInt(hex, 16));
@@ -676,6 +724,33 @@ function _escapeURIPathComponents(path) {
 }
 
 /**
+ * Collapses every run of duplicate literal '/' characters in a raw,
+ * still-percent-encoded URI path into a single slash. S3 keys are flat
+ * strings, so a forwarded duplicate slash can only match a key that
+ * literally contains consecutive slashes - every other double-slash
+ * request failed upstream and surfaced as a sanitized 404 (GH-88).
+ * Collapsing happens before the path is percent-decoded, so a
+ * percent-encoded slash (%2F) is key data, never a separator: a key
+ * genuinely containing consecutive slashes stays addressable as e.g.
+ * /b/%2Fe.txt - _escapeURIPath() decodes and re-encodes per component
+ * afterwards, preserving the empty component the encoded slash produces.
+ *
+ * @param uriPath {string} raw, percent-encoded URI path
+ * @returns {string} path with runs of literal slashes collapsed
+ * @private
+ */
+function _collapseDuplicateSlashes(uriPath) {
+    // Almost no request contains '//', and this runs several times per
+    // request ($uri_full_path, s3uri(), the signers, redirectToS3), so skip
+    // the comparatively expensive njs regex replace on the common case -
+    // the same guard idiom as _escapeURIPath's indexOf('%') check.
+    if (uriPath.indexOf('//') === -1) {
+        return uriPath;
+    }
+    return uriPath.replace(/\/{2,}/g, '/');
+}
+
+/**
  * Determines if a given path is a directory based on whether or not the last
  * character in the path is a forward slash (/).
  *
@@ -723,6 +798,7 @@ export default {
     s3date,
     s3auth,
     s3uri,
+    uriFullPath,
     trailslashControl,
     trailslashRedirectUri,
     redirectToS3,
@@ -733,6 +809,7 @@ export default {
     // unit tests can run against them.
     _s3ReqParamsForSigV2,
     _s3ReqParamsForSigV4,
+    _collapseDuplicateSlashes,
     _encodeURIComponent,
     _escapeURIPath,
     _hasExtension,

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -6,12 +6,12 @@ js_import /etc/nginx/include/s3gateway.js;
 # we plan to use.
 include /etc/nginx/conf.d/gateway/v${AWS_SIGS_VERSION}_js_vars.conf;
 
-# Extracts only the path from the requested URI. This strips out all query
-# parameters and anchors in order to prevent extraneous data from being sent
-# to S3.
-map $request_uri $uri_full_path {
-    "~^(?P<path>.*?)(\?.*)*$"  $path;
-}
+# The client-facing request path: $request_uri with the query string
+# stripped (to prevent extraneous data from being sent to S3) and runs of
+# duplicate literal slashes collapsed (GH-88). Collapsing must happen here,
+# BEFORE the STRIP/PREFIX map below chooses its rewrite arm - a map cannot
+# do a global replace, so this variable is njs-derived.
+js_set $uri_full_path s3gateway.uriFullPath;
 
 # Remove/replace a portion of request URL (if configured)
 map $uri_full_path $uri_path {

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -186,6 +186,21 @@ S3 bucket in a subfolder on an ALB. For example, if you wanted to expose the
 root of a bucket under the path `www.mysite.com/somepath`, you would set this
 variable to `/somepath`.
 
+### Path Normalization
+
+Runs of duplicate literal slashes in a request path are collapsed into a single slash before the gateway signs and
+proxies the request, on every code path (object fetch, index-page probing, and directory listing):
+`/pathFoo//file.txt` is served as the S3 key `pathFoo/file.txt`, and `GET /pathFoo//sub///` lists the prefix
+`pathFoo/sub/`. S3 keys are flat strings, so a forwarded duplicate slash could only ever match a key that literally
+contains consecutive slashes; every other double-slash request failed upstream and surfaced as a sanitized `404`.
+Collapsing happens before `STRIP_LEADING_DIRECTORY_PATH`/`PREFIX_LEADING_DIRECTORY_PATH` rewriting, so a
+duplicate-slash spelling follows the same strip/prefix rewrite as its canonical form.
+
+Only literal slashes are collapsed. A percent-encoded slash (`%2F`) is object-key data, not a path separator, so a
+key that genuinely contains consecutive slashes (e.g. `b//e.txt`) remains addressable by encoding the extra slash:
+`GET /b/%2Fe.txt`. Because all duplicate-slash spellings of a path normalize to one S3 request URI, they share one
+cache entry (see [Byte-Range Requests and Caching](#byte-range-requests-and-caching)).
+
 ## Byte-Range Requests and Caching
 
 The gateway caches [byte-range](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests) (requests sent with a
@@ -214,9 +229,10 @@ Error responses from the origin are cached just like successful ones: an upstrea
 `PROXY_CACHE_VALID_NOTFOUND` (default `1m`) and an upstream `403` for `PROXY_CACHE_VALID_FORBIDDEN` (default `30s`).
 Because cache entries are keyed by the effective S3 request identity (see
 [Byte-Range Requests and Caching](#byte-range-requests-and-caching)), a cached error is shared exactly like a cached
-object: percent-encoding variants of an object URL normalize to the same key (except that with `ALLOW_DIRECTORY_LIST`
-or `PROVIDE_INDEX_PAGE` enabled, a directory's trailing slash must be sent literally — `/dir%2F` is keyed as an object
-request, separately from `/dir/`), and the viewer's `Host` header is not part of the key, so whichever request reaches
+object: percent-encoding variants of an object URL normalize to the same key and duplicate literal slashes are
+collapsed (see [Path Normalization](#path-normalization)) — except that with `ALLOW_DIRECTORY_LIST`
+or `PROVIDE_INDEX_PAGE` enabled, a directory's trailing slash must be sent literally (`/dir%2F` is keyed as an object
+request, separately from `/dir/`) — and the viewer's `Host` header is not part of the key, so whichever request reaches
 the origin first decides what every client using the same request method sees for that object until the entry expires
 (a cached `GET` error is not returned to `HEAD` probes such as `curl -I`).
 

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -21,6 +21,9 @@ set -o pipefail  # don't hide errors within pipes
 
 test_server=$1
 test_dir=$2
+# Accepted to keep the caller CLI contract stable but currently unused: the
+# last signature-version branch (the v4-only //statichost redirect gate) was
+# removed by GH-88, which made the assertion hold under both versions.
 signature_version=$3
 allow_directory_list=$4
 index_page=$5
@@ -396,12 +399,32 @@ if [ -n "${prefix_leading_directory_path}" ]; then
       # strip map arm on loopback: ${strip_leading_directory}/index.html must
       # strip and prefix to the same S3 key as /index.html.
       assertHttpRequestEquals "GET" "${strip_leading_directory}/" "data/bucket-1/statichost/index.html"
+      # GH-88: the collapse precedes the strip on the index probe's loopback
+      # re-entry too - a doubled-slash spelling of the stripped prefix must
+      # land on the same index page instead of bypassing the strip.
+      assertHttpRequestEquals "GET" "/${strip_leading_directory}//" "data/bucket-1/statichost/index.html"
     fi
 
     # Exit early like the non-index prefix branch below: everything past the
     # prefix block assumes unprefixed paths.
     exit 0
   fi
+
+  if [ -n "${strip_leading_directory}" ]; then
+    # GH-88: duplicate slashes collapse BEFORE the STRIP map chooses its
+    # rewrite arm, so a doubled slash at the stripped prefix must take the
+    # same strip+prefix rewrite as the canonical spelling - uncollapsed it
+    # would fail the map's anchored regex, skip the strip, and address the
+    # wrong S3 key. Cold-cache: stays ABOVE every other request for
+    # b/c/d.txt (all slash spellings share one cache entry keyed on the
+    # normalized $s3uri, and a warmed entry would mask the regression).
+    assertHttpRequestEquals "GET" "/${strip_leading_directory}//c/d.txt" "data/bucket-1/b/c/d.txt"
+  fi
+
+  # GH-88: duplicate client slashes collapse after the PREFIX map prepends
+  # /b, so the rewritten path reaches S3 without empty segments. Cold-cache
+  # in no-strip legs: stays above the canonical /c/d.txt request below.
+  assertHttpRequestEquals "GET" "/c//d.txt" "data/bucket-1/b/c/d.txt"
 
   assertHttpRequestEquals "GET" "/c/d.txt" "data/bucket-1/b/c/d.txt"
 
@@ -481,16 +504,37 @@ if [ ${is_windows} == "0" ]; then
   assertHttpRequestEquals "GET" 'a/%25%40!*()%3D%24%23%5E%26%7C.txt' 'data/bucket-1/a/%@!*()=$#^&|.txt'
 fi
 
+# GH-88: runs of duplicate literal slashes collapse before the request is
+# signed and proxied, so these alias the canonical keys requested below.
+# They must stay ABOVE the first canonical-form request for the same
+# object, for the same cold-cache reason as the GH-578 block above: all
+# slash spellings share one cache entry keyed on the normalized $s3uri,
+# so a cache warmed by the canonical form would hide a signing or
+# normalization regression.
+assertHttpRequestEquals "HEAD" "b//e.txt" "200"
+assertHttpRequestEquals "GET" "b//e.txt" "data/bucket-1/b/e.txt"
+assertHttpRequestEquals "GET" "b//c///d.txt" "data/bucket-1/b/c/d.txt"
+# The escape hatch: a percent-encoded slash is object-key data, never a
+# path separator, and is not collapsed. b/%2Fe.txt addresses the distinct
+# key 'b//e.txt' (which no fixture carries) under its own cache key
+# '/b//e.txt', so it must NOT alias the b/e.txt entry warmed above.
+assertHttpRequestEquals "HEAD" "b/%2Fe.txt" "404"
+
+if [ -n "${strip_leading_directory}" ]; then
+  # GH-88: duplicate slashes collapse BEFORE the STRIP map chooses its
+  # rewrite arm, so a leading doubled slash must not bypass the strip
+  # (uncollapsed, '//<strip>/...' fails the map's anchored regex and the
+  # unstripped path becomes the S3 key). Cold-cache: a.txt's canonical
+  # spelling is first requested below.
+  assertHttpRequestEquals "HEAD" "/${strip_leading_directory}//a.txt" "200"
+fi
+
 # Ordinary filenames
 assertHttpRequestEquals "HEAD" "a.txt" "200"
 assertHttpRequestEquals "HEAD" "a.txt?some=param&that=should&be=stripped#aaah" "200"
 assertHttpRequestEquals "HEAD" "b/c/d.txt" "200"
 assertHttpRequestEquals "HEAD" "b/c/../e.txt" "200"
 assertHttpRequestEquals "HEAD" "b/e.txt" "200"
-# Double slashes are preserved in the S3 URI, so this is a distinct missing
-# object rather than an alias for b/e.txt. A cache key based on nginx's
-# normalized $uri would incorrectly reuse the b/e.txt entry here.
-assertHttpRequestEquals "HEAD" "b//e.txt" "404"
 assertHttpRequestEquals "HEAD" "a/abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.txt" "200"
 
 # Byte range requests
@@ -545,9 +589,15 @@ fi
 if [ "${append_slash}" == "1" ] && [ "${index_page}" == "0" ]; then
   assertHttpRequestEquals "HEAD" "not%20found" "302"
   assertHttpRequestEquals "HEAD" "b/c" "302"
+  # GH-88: b//c collapses to b/c and follows the same append-slash path.
+  assertHttpRequestEquals "HEAD" "b//c" "302"
+  # The Location is built from nginx's slash-merged $uri, so the duplicate
+  # slash cannot survive into the redirect target either.
+  assertRedirectLocation "/b//c" "a.example" "/b/c/"
 else
   assertHttpRequestEquals "HEAD" "not%20found" "404"
   assertHttpRequestEquals "HEAD" "b/c" "404"
+  assertHttpRequestEquals "HEAD" "b//c" "404"
 fi
 
 # Directory HEAD 404s
@@ -565,9 +615,6 @@ fi
 assertHttpRequestEquals "HEAD" "b/" "404"
 assertHttpRequestEquals "HEAD" "/b/c/" "404"
 assertHttpRequestEquals "HEAD" "/soap" "404"
-# As with b//e.txt above, b//c is a distinct S3 key and must not inherit the
-# normalized /b/c response from another cache entry.
-assertHttpRequestEquals "HEAD" "b//c" "404"
 
 if [ "${index_page}" == "1" ]; then
 assertHttpRequestEquals "HEAD" "/statichost/" "200"
@@ -672,12 +719,13 @@ assertHttpRequestEquals "GET" "/statichost/noindexdir/multipledir/" "data/bucket
   assertRedirectLocation "/%23foo" "a.example" "/%23foo/"
   assertRedirectLocation "/%25foo" "a.example" "/%25foo/"
   assertRedirectLocation "/foo%0D%0AX-Evil%3A%20yes" "a.example" "/foo%0D%0AX-Evil%3A%20yes/"
-  # MinIO's SigV2 handling returns a plain 404 for this distinct double-slash
-  # key before the gateway reaches @trailslash. SigV4 reaches the redirect and
-  # proves the emitted Location cannot become a scheme-relative `//...` URL.
-  if [ "${signature_version}" == "4" ]; then
-    assertRedirectLocation "//statichost" "a.example" "/statichost/"
-  fi
+  # GH-88: the duplicate slash is collapsed before signing and proxying
+  # under BOTH signature versions (pre-fix, MinIO's SigV2 handling 404'd
+  # the raw double-slash key upstream, so this only held for v4), so S3
+  # returns a plain 404 for 'statichost' and @trailslash emits the
+  # collapsed Location - which also proves it cannot become a
+  # scheme-relative `//...` URL.
+  assertRedirectLocation "//statichost" "a.example" "/statichost/"
   fi
 
   if [ "${allow_directory_list}" == "1" ]; then
@@ -698,6 +746,20 @@ if [ "${allow_directory_list}" == "1" ]; then
   assertHttpRequestEquals "GET" "b/クズ箱/" "200"
   assertHttpRequestEquals "GET" "%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B/" "200"
   assertHttpRequestEquals "GET" "системы/" "200"
+  # GH-88: duplicate slashes collapse in ListObjectsV2 prefixes too, and
+  # '//' aliases the root listing. The body assertion matters: an
+  # uncollapsed '//' would list the (nonexistent) prefix '/' and still
+  # render a 200 "No Files Available for Listing" page. With
+  # PROVIDE_INDEX_PAGE on, the collapsed root instead resolves to the root
+  # index page before the listing branch is consulted.
+  if [ "${index_page}" == "0" ]; then
+    assertHttpRequestEquals "GET" "//" "200"
+    assertHttpBodyPart "contains" "//" '<h1>Index of /</h1>'
+  else
+    assertHttpRequestEquals "GET" "//" "data/bucket-1/index.html"
+  fi
+  assertHttpBodyPart "contains" "b//c///" '<h1>Index of /b/c/</h1>'
+  assertHttpBodyPart "contains" "b//c///" 'href="/b/c/d.txt"'
   if [ "$append_slash" == "1" ]; then
     if [ "${index_page}" == "0" ]; then
       assertHttpRequestEquals "GET" "b" "302"
@@ -707,6 +769,13 @@ if [ "${allow_directory_list}" == "1" ]; then
   fi
 elif [ "${index_page}" == "1" ]; then
   assertHttpRequestEquals "GET" "/" "data/bucket-1/index.html"
+  # GH-88: '//' collapses to the root and serves the same index page.
+  assertHttpRequestEquals "GET" "//" "data/bucket-1/index.html"
 else
   assertHttpRequestEquals "GET" "/" "404"
+  # GH-88 guard: '//' collapses to the root and must hit the same 404
+  # guard in redirectToS3 - not bypass the uriPath === '/' check and
+  # proxy a signed bucket-root GET upstream, which would leak an object
+  # listing while directory listing is disabled.
+  assertHttpRequestEquals "GET" "//" "404"
 fi

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -475,6 +475,22 @@ function testS3uri() {
             '/a/c/');
         check('virtual-v2', undefined, '/b/a/c/', '/b/a/c/', '/a/c/');
         check('path', undefined, '/b/a/c/', `/${bucket}/b/a/c/`, '/a/c/');
+
+        // GH-88: runs of duplicate literal slashes collapse on both the
+        // S3-addressed and the gateway-addressed (index-probe) paths, for
+        // every addressing style.
+        check('virtual-v2', undefined, '/pathFoo//file.txt',
+            '/pathFoo/file.txt');
+        check('virtual-v2', undefined, '//pathFoo//sub///', '/pathFoo/sub/');
+        check('path', undefined, '/pathFoo//file.txt',
+            `/${bucket}/pathFoo/file.txt`);
+        check('path', { preserveBasePath: true }, '/pathFoo//file.txt',
+            '/pathFoo/file.txt');
+        check('virtual-v2', undefined, '//', '/');
+        // The %2F escape hatch: an encoded slash is never collapsed and
+        // survives decode/re-encode as the empty path component that
+        // addresses a key containing consecutive slashes.
+        check('virtual-v2', undefined, '/b/%2Fe.txt', '/b//e.txt');
     } finally {
         restoreEnv('S3_STYLE', savedStyle);
     }
@@ -550,13 +566,138 @@ function testS3ReqParamsForSigV2() {
         // it prepended - both must yield the same signed resource.
         check('path', '/a/plus+plus.txt', `/${bucket}/a/plus%2Bplus.txt`);
         check('path', '/%61.txt', `/${bucket}/a.txt`);
+
+        // GH-88: duplicate literal slashes collapse into the signed v2
+        // resource exactly as they collapse into the proxied URI.
+        check('virtual-v2', '/a//c///ramen.jpg', `/${bucket}/a/c/ramen.jpg`);
+        check('path', '/a//c///ramen.jpg', `/${bucket}/a/c/ramen.jpg`);
+        // The %2F escape hatch signs the preserved empty component.
+        check('virtual-v2', '/b/%2Fe.txt', `/${bucket}/b//e.txt`);
     } finally {
         restoreEnv('S3_STYLE', savedStyle);
     }
 }
 
+function testS3ReqParamsForSigV4() {
+    printHeader('testS3ReqParamsForSigV4');
+
+    const savedStyle = process.env['S3_STYLE'];
+    const bucket = process.env['S3_BUCKET_NAME'];
+    const host = 'unit.test.example.com';
+
+    function makeRequest(uriPath, forIndexPage) {
+        const r = {
+            "method": "GET",
+            "variables": {
+                "uri_path": uriPath,
+                "uri_full_path": uriPath,
+                "forIndexPage": forIndexPage
+            }
+        };
+        r.log = function(msg) {
+            console.log(msg);
+        };
+        return r;
+    }
+
+    function check(style, uriPath, forIndexPage, expectedUri,
+        expectedQueryParams) {
+        process.env['S3_STYLE'] = style;
+        const params = s3gateway._s3ReqParamsForSigV4(
+            makeRequest(uriPath, forIndexPage), bucket, host);
+        if (params.uri !== expectedUri ||
+            params.queryParams !== expectedQueryParams) {
+            throw `Unexpected signed v4 params for S3_STYLE=${style} ` +
+                `uri_path=${uriPath} forIndexPage=${forIndexPage}` +
+                `\nActual:   [${params.uri}] [${params.queryParams}]` +
+                `\nExpected: [${expectedUri}] [${expectedQueryParams}]`;
+        }
+    }
+
+    try {
+        // GH-88: _s3ReqParamsForSigV4 reads $uri_path independently of
+        // s3uri(), so it must collapse duplicate literal slashes the same
+        // way or the signature diverges from the proxied request. Object
+        // paths sign the collapsed s3uri() value...
+        check('virtual-v2', '/a//c///ramen.jpg', 'true',
+            '/a/c/ramen.jpg', '');
+        // ...and directory-listing query params are derived from the
+        // collapsed prefix ($forIndexPage is 'false' as @s3Directory sets
+        // it; _s3DirQueryParams has no ALLOW_LISTING gate, so the listing
+        // params are unit-testable even though s3uri()'s listing branch is
+        // not - see testS3ReqParamsForSigV2's comment).
+        check('virtual-v2', '/b//c///', 'false',
+            '/', 'delimiter=%2F&prefix=b%2Fc%2F');
+        check('path', '/b//c///', 'false',
+            `/${bucket}`, 'delimiter=%2F&prefix=b%2Fc%2F');
+        // '//' collapses to the bucket root: delimiter only, no prefix.
+        check('virtual-v2', '//', 'false', '/', 'delimiter=%2F');
+    } finally {
+        restoreEnv('S3_STYLE', savedStyle);
+    }
+}
+
+function testCollapseDuplicateSlashes() {
+    printHeader('testCollapseDuplicateSlashes');
+    const testCases = [
+        ['/pathFoo//file.txt', '/pathFoo/file.txt'],
+        ['//pathFoo//sub///', '/pathFoo/sub/'],
+        ['//', '/'],
+        ['/', '/'],
+        ['/already/clean.txt', '/already/clean.txt'],
+        // A percent-encoded slash is object-key data, not a separator
+        ['/b/%2Fe.txt', '/b/%2Fe.txt'],
+        ['/b/%2F//e.txt', '/b/%2F/e.txt']
+    ];
+
+    testCases.forEach(function(testCase) {
+        const actual = s3gateway._collapseDuplicateSlashes(testCase[0]);
+        console.log(`  ## testCollapseDuplicateSlashes: ` +
+            `${testCase[0]} => ${testCase[1]}`);
+        if (actual !== testCase[1]) {
+            throw `Collapsed [${testCase[0]}] to [${actual}]` +
+                `\nExpected: [${testCase[1]}]`;
+        }
+    });
+}
+
+function testUriFullPath() {
+    printHeader('testUriFullPath');
+    // $uri_full_path is js_set-derived: the query string is stripped and
+    // duplicate literal slashes collapse BEFORE the STRIP/PREFIX map reads
+    // this value, so every slash spelling takes the same rewrite arm (GH-88).
+    const testCases = [
+        ['/a//b.txt?some=param&other=param', '/a/b.txt'],
+        ['//tostrip//c///d.txt', '/tostrip/c/d.txt'],
+        ['/plain.txt', '/plain.txt'],
+        // A percent-encoded slash is object-key data, never collapsed.
+        ['/b/%2Fe.txt?x=1', '/b/%2Fe.txt'],
+        ['//?delimiter=/', '/']
+    ];
+
+    testCases.forEach(function(testCase) {
+        const r = {
+            "variables": {
+                "request_uri": testCase[0]
+            }
+        };
+        const actual = s3gateway.uriFullPath(r);
+        console.log(`  ## testUriFullPath: ` +
+            `${testCase[0]} => ${testCase[1]}`);
+        if (actual !== testCase[1]) {
+            throw `uriFullPath([${testCase[0]}]) returned [${actual}]` +
+                `\nExpected: [${testCase[1]}]`;
+        }
+    });
+}
+
 function testEscapeURIPathPreservesDoubleSlashes() {
     printHeader('testEscapeURIPathPreservesDoubleSlashes');
+    // _escapeURIPath must keep preserving empty path components: duplicate
+    // LITERAL slashes are collapsed earlier, on the still-encoded path
+    // (s3uri()/the signers, GH-88), so any '//' reaching this function is
+    // the decoded form of an intentional %2F and is the only remaining way
+    // to address a key that genuinely contains consecutive slashes.
     var doubleSlashed = '/testbucketer2/foo3//bar3/somedir/license';
     var actual = s3gateway._escapeURIPath(doubleSlashed);
     var expected = '/testbucketer2/foo3//bar3/somedir/license';
@@ -703,6 +844,9 @@ async function test() {
     testTrailslashRedirectUri();
     testS3uri();
     testS3ReqParamsForSigV2();
+    testS3ReqParamsForSigV4();
+    testCollapseDuplicateSlashes();
+    testUriFullPath();
     testEscapeURIPathPreservesDoubleSlashes();
     await testEcsCredentialRetrieval();
     await testEc2CredentialRetrieval();


### PR DESCRIPTION
Fixes #88.

## Problem

Runs of literal `/` in a request path flowed byte-for-byte from `$request_uri` into the S3 object key and the ListObjectsV2 `prefix`, so `/pathFoo//file.txt` and `/pathFoo//sub///` could only match keys literally containing consecutive slashes — everything else surfaced as a sanitized 404 or an empty listing.

A rewrite-rule fix was tried in #99 and rejected: a `rewrite ... redirect` cannot preserve the client-visible scheme/host/port behind proxies. Per that discussion, this PR normalizes in njs and serves content transparently, with no client-facing 302.

## Approach

`$uri_full_path` is now derived by `js_set` from a new `uriFullPath()` (query strip + collapse of literal slash runs) instead of the old `map $request_uri` regex, so normalization happens at the variable source, **before** the `STRIP/PREFIX_LEADING_DIRECTORY_PATH` map chooses its rewrite arm — an uncollapsed `//stripped-prefix/...` would fail the map's anchored regex and bypass the strip entirely, addressing an unintended S3 key.

Because the PREFIX rewrite can itself rejoin a `//` into `$uri_path` (a prefix value with a trailing slash), the collapse is retained at the njs read sites as well:

- `s3uri()` (both branches) — feeds `proxy_pass`, both `proxy_cache_key`s, the index-probe loopback, and the SigV2 `CanonicalizedResource`, preserving the #578 signed-equals-proxied invariant;
- `_s3ReqParamsForSigV4()` — its independent `$uri_path` read derives the *signed* listing query params, which would otherwise diverge from the proxied prefix with `SignatureDoesNotMatch`;
- `redirectToS3()` — an uncollapsed `GET //` would bypass the `uriPath === "/"` root guard and proxy a signed bucket-root GET, leaking an object listing while directory listing is disabled.

## The edge case from the issue thread

Only **literal** slashes collapse. A percent-encoded slash (`%2F`) is object-key data, so keys genuinely containing consecutive slashes remain addressable by encoding them: `GET /b/%2Fe.txt` → key `b//e.txt` (`_escapeURIPath()` still decodes and re-encodes per component, preserving the empty component). This answers the "someone names their object `/file.txt`" concern without a config toggle. `editHeaders()` now classifies directory HEADs on the raw path for the same reason: decoding there turned a trailing `%2F` into a separator and stripped an object response's headers as if it were a listing.

## Behavior changes (deliberate)

- `b//e.txt` now aliases `b/e.txt` and shares its cache entry (all slash spellings normalize to one `$s3uri`); the suite previously pinned the opposite (`b//e.txt → 404`) and those assertions were inverted on purpose.
- `b//c` follows `b/c` through the append-slash matrix, and its 302 `Location` is the collapsed `/b/c/`.
- The `//statichost` redirect assertion now runs under SigV2 as well — the upstream never sees the raw `//` key that MinIO's v2 handling used to 404.
- `GET //` with listing and index pages disabled stays a 404 (root-guard), with an integration probe pinning the would-be listing leak.

## Testing

- New unit tests: `testCollapseDuplicateSlashes`, `testS3ReqParamsForSigV4` (pins the independent signed-prefix read), `testUriFullPath`, plus `//` and `%2F` cases in `testS3uri` and `testS3ReqParamsForSigV2`.
- Integration: double-slash object/listing/root probes placed above the canonical requests (cold-cache discipline from the #578 block, so the collapsed form is signed upstream rather than served from a warmed entry), STRIP-leg probes for the map bypass, prefix-seam probe, and the `%2F` escape-hatch 404.
- Full suite green on `S3_STYLE=virtual` and `S3_STYLE=path` (`make test`, `make retest`): all integration legs, both signature versions, unit tests in both session-token modes. `make lint` passes.
- Docs: new "Path Normalization" section in `docs/getting_started.md`; smoke-test skill references updated to pin the new contract.