### PR TITLE
fix: render Next page only for prefix-anchored NextMarker values

### DIFF
--- a/common/etc/nginx/include/listing.xsl
+++ b/common/etc/nginx/include/listing.xsl
@@ -125,15 +125,19 @@
                      list request, so the internal prefix never leaks into
                      the link. The href is a query-only relative reference,
                      resolved against the current directory URL, so no
-                     rootPath handling applies. The guard tests the STRIPPED
-                     marker: when a backend truncates without NextMarker, or
-                     with one that leaves no directory-relative remainder (a
-                     marker equal to the prefix, or an opaque token that
-                     does not contain it), no link renders - njs treats an
-                     empty ?marker= as absent, so an empty-valued link would
-                     reload the same page forever. The no-link fallback is
-                     the same output as before pagination existed. -->
-                <xsl:if test="*[local-name()='IsTruncated']/text() = 'true' and string-length($nextMarker) &gt; 0">
+                     rootPath handling applies. The guard anchors the strip:
+                     substring-after cuts at the FIRST prefix occurrence
+                     anywhere in the string, so only a NextMarker that
+                     literally STARTS WITH the prefix may render a link -
+                     when a backend truncates without NextMarker, with an
+                     opaque token that is not prefix-anchored (stripping such
+                     a token mid-string would fabricate a continuation
+                     point), or with a marker equal to the prefix, no link
+                     renders. njs treats an empty ?marker= as absent, so an
+                     empty-valued link would reload the same page forever.
+                     The no-link fallback is the same output as before
+                     pagination existed. -->
+                <xsl:if test="*[local-name()='IsTruncated']/text() = 'true' and starts-with(*[local-name()='NextMarker']/text(), $globalPrefix) and string-length($nextMarker) &gt; 0">
                     <hr/>
                     <p><a><xsl:attribute name="href">?marker=<xsl:call-template name="encode-marker"><xsl:with-param name="value" select="$nextMarker"/></xsl:call-template></xsl:attribute>Next page</a></p>
                 </xsl:if>

--- a/test/integration/test_directory_listing_pagination.sh
+++ b/test/integration/test_directory_listing_pagination.sh
@@ -142,6 +142,23 @@ assert_next_marker_starts_with() {
   esac
 }
 
+# Asserts that a slashless directory request ($1) draws the append-slash
+# redirect with the marker preserved: Location must equal $2. "|| true": a
+# transport-level curl failure must reach the Location check's diagnostic
+# instead of aborting via errexit with curl's raw exit code.
+assert_redirect_location() {
+  path_and_query=$1
+  expected_location=$2
+  message=$3
+  ${curl_cmd} -s -D "${tmp_dir}/headers.txt" -o /dev/null "${test_server}${path_and_query}" || true
+  location="$(tr -d '\r' < "${tmp_dir}/headers.txt" | awk 'tolower($1) == "location:" { print $2 }')"
+  if [ "${location}" != "${expected_location}" ]; then
+    e "FAIL: ${message}: Location is [${location}], expected [${expected_location}]"
+    tr -d '\r' < "${tmp_dir}/headers.txt" >&2
+    exit ${test_fail_exit_code}
+  fi
+}
+
 if [ -n "${prefix_leading_directory_path}" ]; then
   # PREFIX_LEADING_DIRECTORY_PATH leg (the runner passes "/b"): the client
   # root lists the internal prefix, and neither the rendered links nor the
@@ -166,16 +183,9 @@ if [ -n "${prefix_leading_directory_path}" ]; then
   # The append-slash redirect must preserve the marker under the prefix
   # rewrite too: the internal /b prefix is prepended to /c before the S3
   # 404 routes to @trailslash, and the Location must stay client-facing
-  # (built from $uri, never from the rewritten $uri_path). "|| true": a
-  # transport failure must reach the Location check's diagnostic instead
-  # of aborting via errexit with curl's raw exit code.
-  ${curl_cmd} -s -D "${tmp_dir}/headers.txt" -o /dev/null "${test_server}/c?marker=e.txt" || true
-  location="$(tr -d '\r' < "${tmp_dir}/headers.txt" | awk 'tolower($1) == "location:" { print $2 }')"
-  if [ "${location}" != "/c/?marker=e.txt" ]; then
-    e "FAIL: prefixed append-slash redirect dropped or rewrote the marker: Location is [${location}], expected [/c/?marker=e.txt]"
-    tr -d '\r' < "${tmp_dir}/headers.txt" >&2
-    exit ${test_fail_exit_code}
-  fi
+  # (built from $uri, never from the rewritten $uri_path).
+  assert_redirect_location "/c?marker=e.txt" "/c/?marker=e.txt" \
+    "prefixed append-slash redirect dropped or rewrote the marker"
 
   exit 0
 fi
@@ -289,15 +299,8 @@ fetch_expecting "/b/?marker=%F4%8F%BF%BF" "200"
 assert_page_contains 'No Files Available for Listing' "past-the-end marker renders the empty listing"
 
 # The append-slash redirect must preserve the marker so a paginated URL
-# without the trailing slash still resolves to the right page. "|| true":
-# a transport failure must reach the Location check's diagnostic instead
-# of aborting via errexit with curl's raw exit code.
-${curl_cmd} -s -D "${tmp_dir}/headers.txt" -o /dev/null "${test_server}/b?marker=e.txt" || true
-location="$(tr -d '\r' < "${tmp_dir}/headers.txt" | awk 'tolower($1) == "location:" { print $2 }')"
-if [ "${location}" != "/b/?marker=e.txt" ]; then
-  e "FAIL: append-slash redirect dropped the marker: Location is [${location}], expected [/b/?marker=e.txt]"
-  tr -d '\r' < "${tmp_dir}/headers.txt" >&2
-  exit ${test_fail_exit_code}
-fi
+# without the trailing slash still resolves to the right page.
+assert_redirect_location "/b?marker=e.txt" "/b/?marker=e.txt" \
+  "append-slash redirect dropped the marker"
 
 e "  directory listing pagination probes passed"

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -387,6 +387,22 @@ integration_test_listen_directives() {
   fi
 }
 
+# Proves the gateway actually ran with the AWS signatures version ($1) the
+# leg was configured for: a leg that silently started with the wrong version
+# would pass its assertions without exercising the signing path it exists to
+# test. `|| true` because grep -c exits 1 on a count of zero, which must
+# reach the check below rather than abort the script through errexit before
+# it can print the diagnostic.
+assert_gateway_sig_version() {
+  sig_versions_found_count=$(compose logs nginx-s3-gateway | grep -c "AWS Signatures Version: v$1\|AWS v$1 Auth" || true)
+
+  if [ "${sig_versions_found_count}" -lt 3 ]; then
+    e "NGINX was not detected as using the correct signatures version - examine logs"
+    compose logs nginx-s3-gateway
+    exit "$test_fail_exit_code"
+  fi
+}
+
 integration_test() {
   printf "\033[34;1m▶\033[0m"
   printf "\e[1m Integration test suite for v%s signatures\e[22m\n" "$1"
@@ -416,16 +432,8 @@ integration_test() {
   bash "${test_dir}/integration/test_api.sh" "${test_server}" "${test_dir}" "$1" "$2" "$3" "$4" "$5" "$6";
 
   # We check to see if NGINX is in fact using the correct version of AWS
-  # signatures as it was configured to do. `|| true` because grep -c exits 1
-  # on a count of zero, which must reach the check below rather than abort
-  # the script through errexit before it can print the diagnostic.
-  sig_versions_found_count=$(compose logs nginx-s3-gateway | grep -c "AWS Signatures Version: v$1\|AWS v$1 Auth" || true)
-
-  if [ "${sig_versions_found_count}" -lt 3 ]; then
-    e "NGINX was not detected as using the correct signatures version - examine logs"
-    compose logs nginx-s3-gateway
-    exit "$test_fail_exit_code"
-  fi
+  # signatures as it was configured to do.
+  assert_gateway_sig_version "$1"
 }
 
 integration_test_directory_listing_pagination() {
@@ -451,16 +459,8 @@ integration_test_directory_listing_pagination() {
 
   # The same signature-version proof integration_test performs: the v2 leg
   # exists to exercise marker signing under SigV2, which is only proven if
-  # the gateway actually ran with v2 signatures. `|| true` because grep -c
-  # exits 1 on a count of zero, which must reach the check below rather
-  # than abort the script through errexit before it prints the diagnostic.
-  sig_versions_found_count=$(compose logs nginx-s3-gateway | grep -c "AWS Signatures Version: v${sigs_version}\|AWS v${sigs_version} Auth" || true)
-
-  if [ "${sig_versions_found_count}" -lt 3 ]; then
-    e "NGINX was not detected as using the correct signatures version - examine logs"
-    compose logs nginx-s3-gateway
-    exit "$test_fail_exit_code"
-  fi
+  # the gateway actually ran with v2 signatures.
+  assert_gateway_sig_version "${sigs_version}"
 }
 
 integration_test_cache_bypass() {
@@ -489,7 +489,7 @@ integration_test_cache_bypass() {
   # container, which discards the proxy cache so that each phase starts with
   # an empty cache.
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" PROXY_CACHE_BYPASS_NO_CACHE="${bypass_setting}" compose up -d
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" PROXY_CACHE_BYPASS_NO_CACHE="${bypass_setting}" compose up -d
 
   wait_for_gateway
 
@@ -518,7 +518,7 @@ integration_test_cache_ignore_headers() {
   # environment makes compose recreate the gateway container, which discards
   # the proxy cache so that each phase starts with an empty cache.
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" PROXY_CACHE_BYPASS_NO_CACHE=false PROXY_CACHE_IGNORE_HEADERS="${ignore_headers}" compose up -d
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" PROXY_CACHE_BYPASS_NO_CACHE=false PROXY_CACHE_IGNORE_HEADERS="${ignore_headers}" compose up -d
 
   wait_for_gateway
 
@@ -548,7 +548,7 @@ integration_test_cors() {
   # normalized "1" so the leg also exercises the parseBoolean path in
   # 01-set-defaults.envsh.
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" CORS_ENABLED=true CORS_ALLOWED_ORIGIN="${cors_test_origin}" compose up -d
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" CORS_ENABLED=true CORS_ALLOWED_ORIGIN="${cors_test_origin}" compose up -d
 
   wait_for_gateway
 
@@ -606,7 +606,7 @@ start_tls_gateway() {
   tls_s3_server=${3:-minio}
   export TEST_S3_TRUSTED_CERT_PATH="${trusted_cert_path}"
   export TEST_S3_SERVER="${tls_s3_server}"
-  COMPOSE_COMPATIBILITY=true S3_STYLE="${tls_s3_style}" AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=1 PROVIDE_INDEX_PAGE=1 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=1 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" compose up -d
+  COMPOSE_COMPATIBILITY=true S3_STYLE="${tls_s3_style}" AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=1 PROVIDE_INDEX_PAGE=1 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=1 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose up -d
   wait_for_gateway
 }
 
@@ -654,7 +654,7 @@ integration_test_dynamic_credentials() {
   compose_dynamic_credentials down --volumes --remove-orphans || true
   set_http_test_origin
 
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" compose_dynamic_credentials up -d
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose_dynamic_credentials up -d
   wait_for_gateway
   seed_minio_data
 
@@ -697,7 +697,7 @@ integration_test_secret_file_credentials() {
   printf '%s\n' "${minio_passwd}" > "${test_secrets_dir}/aws_secret_access_key"
   chmod 0444 "${test_secrets_dir}"/aws_*
 
-  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" compose_secret_file_credentials up -d
+  COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose_secret_file_credentials up -d
   wait_for_gateway
   seed_minio_data
 


### PR DESCRIPTION
### Proposed changes

Follow-ups to the directory-listing pagination feature (#586), found in a post-merge review pass.

**`listing.xsl` — anchor the NextMarker prefix strip.** `substring-after` cuts at the *first* occurrence of the listing prefix anywhere in the string, so an opaque backend continuation token that merely contains the prefix mid-string (prefix `b/`, token `tok-b/xyz`) was mis-stripped into a fabricated marker: the page rendered `?marker=xyz`, njs re-prepended the prefix, and the walk continued from a point the backend never issued — skipping or repeating keys. The link guard now also requires `starts-with(NextMarker, $globalPrefix)`, so non-anchored tokens fall into the documented no-link fallback. Root listings are unaffected (`starts-with(x, '')` is true in XPath 1.0). Verified with a libxslt harness across 8 cases: AWS happy path, MinIO-decorated marker, root listing, marker == prefix, mid-string prefix token, non-containing token, not-truncated, and absent NextMarker.

**Test hygiene.** Six compose invocations in `test/run_integration_tests.sh` (cache-bypass, ignore-headers, CORS, TLS, dynamic-credentials, secret-file legs) didn't pin `DIRECTORY_LISTING_PAGE_SIZE=""`, so a stray export in a developer's shell leaked through the new compose pass-through key — an invalid value fails entrypoint validation (not gated on `ALLOW_DIRECTORY_LIST`) and surfaces as opaque `wait_for_gateway` timeouts. Also extracted two copy-pasted assertion blocks into shared helpers (`assert_gateway_sig_version`, `assert_redirect_location`) so the copies can't drift.

Validation: `shellcheck --severity=warning` and `bash -n` clean on both scripts, `make test-unit` passes, libxslt harness all-pass. Relying on the CI matrix for the integration legs.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).