### PR TITLE
test: replace the MinIO origin with RustFS in the integration stack

### DIFF
--- a/.github/actions/install-mc/action.yml
+++ b/.github/actions/install-mc/action.yml
@@ -1,7 +1,7 @@
 ---
-name: Install MinIO Client
+name: Install mc
 description: >
-  Installs the pinned MinIO client (mc) into ./.bin, where the GNUmakefile's
+  Installs the pinned mc S3 client into ./.bin, where the GNUmakefile's
   check-tools target and test/run_integration_tests.sh both look for it. mc
   is used as a generic S3 client against the RustFS test origin.
 inputs:
@@ -16,9 +16,9 @@ runs:
   using: composite
   steps:
     # Downloaded rather than cached: the release is ~25 MB and arrives from
-    # MinIO's CDN in about a second, which is no slower than an actions/cache
+    # the upstream CDN in about a second, which is no slower than an actions/cache
     # round trip and cannot serve a stale binary.
-    - name: Install MinIO Client
+    - name: Install mc
       shell: bash
       env:
         MC_RELEASE: ${{ inputs.release }}

--- a/.github/actions/install-mc/action.yml
+++ b/.github/actions/install-mc/action.yml
@@ -2,7 +2,8 @@
 name: Install MinIO Client
 description: >
   Installs the pinned MinIO client (mc) into ./.bin, where the GNUmakefile's
-  check-tools target and test/run_integration_tests.sh both look for it.
+  check-tools target and test/run_integration_tests.sh both look for it. mc
+  is used as a generic S3 client against the RustFS test origin.
 inputs:
   release:
     description: >

--- a/.github/workflows/s3-gateway.yml
+++ b/.github/workflows/s3-gateway.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install MinIO Client
+      - name: Install mc
         uses: ./.github/actions/install-mc
 
       - name: Build and test - stable njs version
@@ -118,7 +118,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install MinIO Client
+      - name: Install mc
         uses: ./.github/actions/install-mc
 
       # S3_STYLE is pinned the same way the local test-matrix target pins it,
@@ -134,7 +134,7 @@ jobs:
       - name: Check out the codebase
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Install MinIO Client
+      - name: Install mc
         uses: ./.github/actions/install-mc
 
       # S3_STYLE is pinned the same way the local test-matrix target pins it,

--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,7 @@ out/
 # jsdoc build directory
 reference/
 
-# minio storage
+# object-store scratch data
 data/
 
 # mpeltonen/sbt-idea plugin

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Notes:
   (`/etc/nginx/include/`), not the working tree — only `test/unit/` is
   bind-mounted. After editing `common/etc/nginx/include/*.js`, run `make test`
   (rebuilds first); `make retest` would test the stale copy.
-- Integration tests spin up MinIO via `test/docker-compose.yaml` (compose
+- Integration tests spin up a RustFS S3 origin via `test/docker-compose.yaml` (compose
   project `ngt`) and hit the gateway on `localhost:8989`.
 - `S3_STYLE` (`virtual`, `virtual-v2`, or `path`) selects the S3 addressing
   style under test; CI runs all three.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ and test workflows. The test logic lives in `test/run_unit_tests.sh` and
 deprecated wrapper that only forwards to the equivalent make targets — never
 invoke or recommend it. Run `make help` for the full target list,
 `make check-tools` to verify prerequisites (docker, docker compose, curl,
-mc/MinIO client).
+and the mc S3 client).
 
 - `make build` — build the gateway image (`NGINX_TYPE=oss` default, or `plus`).
 - `make test` — build, then run the full unit + integration suite.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -92,7 +92,7 @@ check-tools: ## Verify required build and test tooling is present
 	{ $(DOCKER) compose version > /dev/null 2>&1 || command -v docker-compose > /dev/null 2>&1; } || \
 		{ echo "MISSING (required): docker compose plugin (or legacy docker-compose)"; ok=0; }; \
 	if ! command -v mc > /dev/null 2>&1 && [ ! -x "$(BASE_DIR).bin/mc" ]; then \
-		echo "MISSING (required): mc (MinIO client) - or place the binary at ./.bin/mc"; ok=0; \
+		echo "MISSING (required): mc (MinIO client, used as the generic S3 test client) - or place the binary at ./.bin/mc"; ok=0; \
 	fi; \
 	if ! command -v md5sum > /dev/null 2>&1 && ! command -v md5 > /dev/null 2>&1; then \
 		echo "MISSING (required): md5sum (or md5 on macOS)"; ok=0; \
@@ -325,7 +325,7 @@ clean: ## Remove generated docs and tear down the test compose environment
 		-f "$(COMPOSE_FILE)" -f "$(DYNAMIC_CREDENTIALS_COMPOSE_FILE)" -p $(COMPOSE_PROJECT) \
 		down --volumes --remove-orphans 2> /dev/null || true
 	@mc_cmd="$$(command -v mc || echo "$(BASE_DIR).bin/mc")"; \
-	[ -x "$$mc_cmd" ] && "$$mc_cmd" alias rm $(COMPOSE_PROJECT)_minio_1 2> /dev/null || true
+	[ -x "$$mc_cmd" ] && "$$mc_cmd" alias rm $(COMPOSE_PROJECT)_rustfs_1 2> /dev/null || true
 	@tls_dir="$${TMPDIR:-/tmp}/nginx-s3-gateway-$(COMPOSE_PROJECT)-tls"; \
 	if [ -d "$$tls_dir" ]; then \
 		rm -f "$$tls_dir"/* 2> /dev/null || true; \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -92,7 +92,7 @@ check-tools: ## Verify required build and test tooling is present
 	{ $(DOCKER) compose version > /dev/null 2>&1 || command -v docker-compose > /dev/null 2>&1; } || \
 		{ echo "MISSING (required): docker compose plugin (or legacy docker-compose)"; ok=0; }; \
 	if ! command -v mc > /dev/null 2>&1 && [ ! -x "$(BASE_DIR).bin/mc" ]; then \
-		echo "MISSING (required): mc (MinIO client, used as the generic S3 test client) - or place the binary at ./.bin/mc"; ok=0; \
+		echo "MISSING (required): mc (the S3 test client) - or place the binary at ./.bin/mc"; ok=0; \
 	fi; \
 	if ! command -v md5sum > /dev/null 2>&1 && ! command -v md5 > /dev/null 2>&1; then \
 		echo "MISSING (required): md5sum (or md5 on macOS)"; ok=0; \

--- a/docs/development.md
+++ b/docs/development.md
@@ -76,7 +76,8 @@ not invoke it directly.
 
 Automated tests require `docker`, `docker compose`, `curl`, `md5sum` (or `md5`
 on macOS), and `mc` (the
-[MinIO client](https://min.io/docs/minio/linux/reference/minio-mc.html)) to be
+[MinIO client](https://min.io/docs/minio/linux/reference/minio-mc.html), used
+as a generic S3 client against the RustFS test origin) to be
 installed; run `make check-tools` to verify all prerequisites are present.
 
 To build the gateway image and run the full unit and integration test suite:
@@ -127,7 +128,7 @@ Integration tests live in `test/integration/` and are driven by
 `test/docker-compose.dynamic-credentials.yaml` override supplying an ECS
 credential-endpoint mock for the dynamic-credentials phase and the
 `test/docker-compose.secret-file-credentials.yaml` override supplying the
-static credentials as mounted secret files), seeds MinIO with
+static credentials as mounted secret files), seeds the RustFS S3 origin with
 the fixtures in `test/data/`, and invokes the test scripts across a matrix of
 gateway configurations, including HTTPS origins with TLS verification and a
 CORS-enabled phase. New

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,8 +75,7 @@ script is deprecated and only forwards to the equivalent make targets — do
 not invoke it directly.
 
 Automated tests require `docker`, `docker compose`, `curl`, `md5sum` (or `md5`
-on macOS), and `mc` (the
-[MinIO client](https://min.io/docs/minio/linux/reference/minio-mc.html), used
+on macOS), and [`mc`](https://min.io/docs/minio/linux/reference/minio-mc.html) (used
 as a generic S3 client against the RustFS test origin) to be
 installed; run `make check-tools` to verify all prerequisites are present.
 

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -86,8 +86,8 @@ services:
       timeout: 3s
       retries: 3
   # It may be useful to enable the client container so that you can debug
-  # what calls were made to the origin by the gateway. RustFS exposes a
-  # MinIO-compatible admin API, so mc admin tooling works against it.
+  # what calls were made to the origin by the gateway. RustFS exposes an
+  # admin API compatible with mc's admin subcommands.
 #  origin-client:
 #    depends_on:
 #      - "rustfs"

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -79,7 +79,9 @@ services:
       # TLS leg is the only one that may point this at /tls.
       RUSTFS_TLS_PATH: "${TEST_S3_TLS_PATH:-}"
     healthcheck:
-      test: ["CMD-SHELL", "curl -k -f ${TEST_S3_ORIGIN_PROTO:-http}://localhost:9000/health"]
+      # Probes over the same protocol the gateway uses: RustFS terminates TLS
+      # itself, so the one listener is either plain HTTP or HTTPS for both.
+      test: ["CMD-SHELL", "curl -k -f ${TEST_S3_SERVER_PROTO:-http}://localhost:9000/health"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -1,9 +1,9 @@
 services:
   nginx-s3-gateway:
-    # If minio client is up and running properly, we are reasonably sure that
-    # minio has properly started. That's why we depend on it here.
+    # The healthcheck proves the origin is answering S3 requests, so waiting
+    # on it means the gateway never races the origin's startup.
     depends_on:
-      minio:
+      rustfs:
         condition: service_healthy
     image: "nginx-s3-gateway"
     ports:
@@ -11,13 +11,13 @@ services:
     volumes:
       - "${TEST_TLS_CERT_DIR:-/tmp/nginx-s3-gateway-test-certs}:/etc/nginx/test-certs:ro"
     links:
-      - "minio"
+      - "rustfs"
     restart: "no"
     environment:
       S3_BUCKET_NAME: "bucket-1"
       AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
       AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-      S3_SERVER: "${TEST_S3_SERVER:-minio}"
+      S3_SERVER: "${TEST_S3_SERVER:-rustfs}"
       S3_SERVER_PORT: "${TEST_S3_SERVER_PORT:-9000}"
       S3_SERVER_PROTO: "${TEST_S3_SERVER_PROTO:-http}"
       S3_TRUSTED_CERT_PATH: "${TEST_S3_TRUSTED_CERT_PATH:-/etc/ssl/certs/ca-certificates.crt}"
@@ -51,38 +51,46 @@ services:
       IPV6_ENABLED:
       NGINX_LICENSE_JWT: "${NGINX_LICENSE_JWT-}"
 
-  minio:
-    image: quay.io/minio/minio:RELEASE.2023-06-09T07-32-12Z
-    hostname: bucket-1.minio
+  rustfs:
+    image: rustfs/rustfs:1.0.0-rc.3@sha256:800cf3f352a0a27e3275ca854a51f0027975d7acc7a0d52089a35bcc9fcbf0b5
+    hostname: bucket-1.rustfs
     networks:
       default:
         aliases:
-          - minio-mismatch
+          - rustfs-mismatch
     ports:
       - "9090:9000/tcp"
     restart: "no"
-    command: minio server /data --certs-dir ${TEST_MINIO_CERTS_DIR:-/root/.minio/certs}
     volumes:
-      - "${TEST_TLS_CERT_DIR:-/tmp/nginx-s3-gateway-test-certs}:/tmp/test-certs:ro"
+      - "${TEST_TLS_CERT_DIR:-/tmp/nginx-s3-gateway-test-certs}:/tls:ro"
     environment:
-      MINIO_ADDRESS: :9000
-      MINIO_ROOT_USER: "AKIAIOSFODNN7EXAMPLE"
-      MINIO_ROOT_PASSWORD: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-      MINIO_REGION_NAME: "us-east-1"
-      MINIO_DOMAIN: "minio"
-      MINIO_BROWSER: "off"
+      RUSTFS_ADDRESS: ":9000"
+      RUSTFS_ACCESS_KEY: "AKIAIOSFODNN7EXAMPLE"
+      RUSTFS_SECRET_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      RUSTFS_REGION: "us-east-1"
+      # RustFS suffix-matches the raw Host header against this list to parse
+      # virtual-hosted-style bucket names, so both forms are needed: the
+      # gateway's 'virtual-v2' style sends Host: bucket-1.rustfs:9000 (port
+      # included) while 'virtual' sends Host: bucket-1.rustfs.
+      RUSTFS_SERVER_DOMAINS: "rustfs:9000,rustfs"
+      RUSTFS_CONSOLE_ENABLE: "false"
+      # Empty means plain HTTP. RustFS refuses to start when the path is set
+      # but missing or holds no rustfs_cert.pem/rustfs_key.pem pair, so the
+      # TLS leg is the only one that may point this at /tls.
+      RUSTFS_TLS_PATH: "${TEST_S3_TLS_PATH:-}"
     healthcheck:
-      test: ["CMD-SHELL", "curl -k -f ${TEST_MINIO_SERVER_PROTO:-http}://localhost:9000/minio/health/live"]
+      test: ["CMD-SHELL", "curl -k -f ${TEST_S3_ORIGIN_PROTO:-http}://localhost:9000/health"]
       interval: 5s
       timeout: 3s
       retries: 3
-  # It may be useful to enable minio client so that you can debug what calls
-  # were made to minio by the gateway.
-#  minio-client:
+  # It may be useful to enable the client container so that you can debug
+  # what calls were made to the origin by the gateway. RustFS exposes a
+  # MinIO-compatible admin API, so mc admin tooling works against it.
+#  origin-client:
 #    depends_on:
-#      - "minio"
+#      - "rustfs"
 #    image: "minio/mc"
 #    restart: "no"
 #    command: "admin trace --verbose nginx-test-gateway"
 #    environment:
-#      MC_HOST_nginx-test-gateway: "http://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY@minio:9000"
+#      MC_HOST_nginx-test-gateway: "http://AKIAIOSFODNN7EXAMPLE:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY@rustfs:9000"

--- a/test/integration/ecs_credentials_mock.conf
+++ b/test/integration/ecs_credentials_mock.conf
@@ -6,11 +6,12 @@ http {
     server {
         listen 80;
 
-        # Token is deliberately omitted from the response: MinIO validates any
-        # x-amz-security-token it receives as one of its own STS JWTs and
-        # rejects a fabricated one with InvalidTokenId, which would 403 every
-        # request in this suite. The sessionToken round trip through the
-        # credential cache is covered by the unit tests instead.
+        # Token is deliberately omitted from the response: the S3 origin
+        # (RustFS, like MinIO before it) validates any x-amz-security-token
+        # it receives as one of its own STS-issued tokens and rejects a
+        # fabricated one, which would fail every request in this suite. The
+        # sessionToken round trip through the credential cache is covered by
+        # the unit tests instead.
         location = /credentials {
             default_type application/json;
             return 200 '{"AccessKeyId":"AKIAIOSFODNN7EXAMPLE","SecretAccessKey":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","Expiration":"2100-01-01T00:00:00Z"}';

--- a/test/integration/ecs_credentials_mock.conf
+++ b/test/integration/ecs_credentials_mock.conf
@@ -7,9 +7,9 @@ http {
         listen 80;
 
         # Token is deliberately omitted from the response: the S3 origin
-        # (RustFS, like MinIO before it) validates any x-amz-security-token
-        # it receives as one of its own STS-issued tokens and rejects a
-        # fabricated one, which would fail every request in this suite. The
+        # validates any x-amz-security-token it receives as one of its own
+        # STS-issued tokens and rejects a fabricated one, which would fail
+        # every request in this suite. The
         # sessionToken round trip through the credential cache is covered by
         # the unit tests instead.
         location = /credentials {

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -290,6 +290,46 @@ assertRedirectLocation() {
   fi
 }
 
+# Asserts that a path carrying percent-encoded control bytes cannot inject a
+# response header. Origins differ on the upstream answer for such keys - AWS
+# and MinIO return 404, which makes @trailslash emit a redirect, while RustFS
+# rejects control bytes in object keys with 400 and no redirect is emitted at
+# all. Both shapes are safe, so the redirect itself is optional here; what
+# must never happen is the decoded CR/LF splitting a header, and when a
+# Location IS emitted it must still carry the bytes percent-encoded.
+# assertRedirectSafeFromHeaderInjection <path> <host_header> <expected_location_when_redirected> <injected_header_name>
+assertRedirectSafeFromHeaderInjection() {
+  path="$1"
+  host="$2"
+  expected_location="$3"
+  injected_header_name="$4"
+
+  buildTestUri "${path}"
+
+  printf "  \033[36;1m▲\033[0m "
+  echo "Testing header-injection safety: GET ${path} (Host: ${host})"
+
+  headers="$(${curl_cmd} -H "Host: ${host}" -D - -o /dev/null "${uri}")"
+  actual_location=""
+  while IFS= read -r header; do
+    case "${header}" in
+      [Ll]ocation:\ *)
+        actual_location="${header#*: }"
+        actual_location="${actual_location%$'\r'}"
+        ;;
+      "${injected_header_name}:"*)
+        e "Header injection detected: response contains a '${injected_header_name}' header. Request [GET ${uri} Host: ${host}]"
+        exit ${test_fail_exit_code}
+        ;;
+    esac
+  done <<< "${headers}"
+
+  if [ -n "${actual_location}" ] && [ "${expected_location}" != "${actual_location}" ]; then
+    e "Redirect location didn't match expectation. Request [GET ${uri} Host: ${host}] Expected [${expected_location}] Actual [${actual_location}]"
+    exit ${test_fail_exit_code}
+  fi
+}
+
 # Fetch a URL with GET and assert a literal substring is present in
 # (mode "contains") or absent from (mode "lacks") the response body.
 # The response is fetched once per path and reused by consecutive assertions
@@ -602,7 +642,8 @@ fi
 
 # Directory HEAD 404s
 # Unfortunately, the logic here can't be properly encoded into the test.
-# With minio, we can't return anything *but* a 404 for HEAD requests to a directory.
+# With RustFS (as with MinIO before it), we can't return anything *but* a 404
+# for HEAD requests to a directory.
 # With AWS S3, HEAD requests to a directory will return 200 *only* when we are
 # running with v4 signatures.
 # Now, both of these cases have the exception of HEAD returning 200 on the root
@@ -718,10 +759,11 @@ assertHttpRequestEquals "GET" "/statichost/noindexdir/multipledir/" "data/bucket
   assertRedirectLocation "/%3Ffoo" "a.example" "/%3Ffoo/"
   assertRedirectLocation "/%23foo" "a.example" "/%23foo/"
   assertRedirectLocation "/%25foo" "a.example" "/%25foo/"
-  assertRedirectLocation "/foo%0D%0AX-Evil%3A%20yes" "a.example" "/foo%0D%0AX-Evil%3A%20yes/"
+  assertRedirectSafeFromHeaderInjection "/foo%0D%0AX-Evil%3A%20yes" "a.example" "/foo%0D%0AX-Evil%3A%20yes/" "X-Evil"
   # GH-88: the duplicate slash is collapsed before signing and proxying
-  # under BOTH signature versions (pre-fix, MinIO's SigV2 handling 404'd
-  # the raw double-slash key upstream, so this only held for v4), so S3
+  # under BOTH signature versions (pre-fix, the then-MinIO origin's SigV2
+  # handling 404'd the raw double-slash key upstream, so this only held
+  # for v4), so S3
   # returns a plain 404 for 'statichost' and @trailslash emits the
   # collapsed Location - which also proves it cannot become a
   # scheme-relative `//...` URL.

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -311,8 +311,12 @@ assertRedirectSafeFromHeaderInjection() {
 
   headers="$(${curl_cmd} -H "Host: ${host}" -D - -o /dev/null "${uri}")"
   actual_location=""
+  status=""
   while IFS= read -r header; do
     case "${header}" in
+      HTTP/*)
+        status="$(echo "${header}" | awk '{print $2}')"
+        ;;
       [Ll]ocation:\ *)
         actual_location="${header#*: }"
         actual_location="${actual_location%$'\r'}"
@@ -323,6 +327,19 @@ assertRedirectSafeFromHeaderInjection() {
         ;;
     esac
   done <<< "${headers}"
+
+  # Both safe upstream shapes are 3xx (redirect emitted) or 4xx (origin
+  # rejected the control bytes). A 2xx means the decoded key unexpectedly
+  # resolved; a 5xx means the gateway itself broke on the input. Either
+  # would previously have slipped through because only the redirect
+  # location, when present, was being checked.
+  case "${status}" in
+    3*|4*) ;;
+    *)
+      e "Unexpected status for a control-byte path. Request [GET ${uri} Host: ${host}] Status [${status}]"
+      exit ${test_fail_exit_code}
+      ;;
+  esac
 
   if [ -n "${actual_location}" ] && [ "${expected_location}" != "${actual_location}" ]; then
     e "Redirect location didn't match expectation. Request [GET ${uri} Host: ${host}] Expected [${expected_location}] Actual [${actual_location}]"

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -292,7 +292,7 @@ assertRedirectLocation() {
 
 # Asserts that a path carrying percent-encoded control bytes cannot inject a
 # response header. Origins differ on the upstream answer for such keys - AWS
-# and MinIO return 404, which makes @trailslash emit a redirect, while RustFS
+# answers 404, which makes @trailslash emit a redirect, while RustFS
 # rejects control bytes in object keys with 400 and no redirect is emitted at
 # all. Both shapes are safe, so the redirect itself is optional here; what
 # must never happen is the decoded CR/LF splitting a header, and when a
@@ -659,7 +659,7 @@ fi
 
 # Directory HEAD 404s
 # Unfortunately, the logic here can't be properly encoded into the test.
-# With RustFS (as with MinIO before it), we can't return anything *but* a 404
+# With RustFS, we can't return anything *but* a 404
 # for HEAD requests to a directory.
 # With AWS S3, HEAD requests to a directory will return 200 *only* when we are
 # running with v4 signatures.
@@ -778,7 +778,7 @@ assertHttpRequestEquals "GET" "/statichost/noindexdir/multipledir/" "data/bucket
   assertRedirectLocation "/%25foo" "a.example" "/%25foo/"
   assertRedirectSafeFromHeaderInjection "/foo%0D%0AX-Evil%3A%20yes" "a.example" "/foo%0D%0AX-Evil%3A%20yes/" "X-Evil"
   # GH-88: the duplicate slash is collapsed before signing and proxying
-  # under BOTH signature versions (pre-fix, the then-MinIO origin's SigV2
+  # under BOTH signature versions (pre-fix, the previous origin's SigV2
   # handling 404'd the raw double-slash key upstream, so this only held
   # for v4), so S3
   # returns a plain 404 for 'statichost' and @trailslash emits the

--- a/test/integration/test_cache_bypass.sh
+++ b/test/integration/test_cache_bypass.sh
@@ -18,7 +18,7 @@
 
 # Integration tests for the PROXY_CACHE_BYPASS_NO_CACHE feature. The gateway
 # must already be running with the feature configured; this script only
-# issues requests and mutates objects in the MinIO backend to prove whether
+# issues requests and mutates objects in the S3 origin to prove whether
 # a request with Cache-Control: no-cache bypasses the local proxy cache.
 #
 # The test relies on PROXY_CACHE_VALID_OK being long (1h in the test compose
@@ -32,8 +32,8 @@ test_server=$1
 test_dir=$2
 phase=$3
 mc_cmd=$4
-minio_alias=$5
-minio_bucket=$6
+origin_alias=$5
+origin_bucket=$6
 
 test_fail_exit_code=2
 no_dep_exit_code=3
@@ -65,13 +65,13 @@ if ! [ -x "${mc_cmd}" ]; then
   exit ${no_dep_exit_code}
 fi
 
-if [ -z "${minio_alias}" ]; then
-  e "missing fifth parameter: mc alias of the MinIO backend"
+if [ -z "${origin_alias}" ]; then
+  e "missing fifth parameter: mc alias of the S3 origin"
   exit ${no_dep_exit_code}
 fi
 
-if [ -z "${minio_bucket}" ]; then
-  e "missing sixth parameter: name of the MinIO bucket"
+if [ -z "${origin_bucket}" ]; then
+  e "missing sixth parameter: name of the S3 origin bucket"
   exit ${no_dep_exit_code}
 fi
 
@@ -106,7 +106,7 @@ if [[ $checksum_cmd =~ \/md5$ ]]; then
   checksum_cmd="${checksum_cmd} -r"
 fi
 
-fixture_dir="${test_dir}/data/${minio_bucket}/cache-bypass"
+fixture_dir="${test_dir}/data/${origin_bucket}/cache-bypass"
 
 # Populates the curl_args array with the optional Host and Cache-Control
 # request headers shared by the assertion helpers below, so the two helpers
@@ -185,14 +185,14 @@ assertRangeGetEquals() {
   fi
 }
 
-# Overwrites an object in the MinIO backend with the contents of a local
+# Overwrites an object in the S3 origin with the contents of a local
 # file, without touching the gateway's cache.
 # overwriteObject <local_src_file> <object_key>
 overwriteObject() {
   local_src="$1"
   object_key="$2"
-  echo "  Overwriting object ${minio_bucket}/${object_key} with contents of $(basename "${local_src}")"
-  "${mc_cmd}" cp "${local_src}" "${minio_alias}/${minio_bucket}/${object_key}" > /dev/null
+  echo "  Overwriting object ${origin_bucket}/${object_key} with contents of $(basename "${local_src}")"
+  "${mc_cmd}" cp "${local_src}" "${origin_alias}/${origin_bucket}/${object_key}" > /dev/null
 }
 
 # Check to see if HTTP server is available
@@ -261,7 +261,7 @@ if [ "${phase}" = "disabled" ]; then
   assertRangeGetEquals "/cache-bypass/sliced.txt" "${fixture_dir}/updated.txt" 10 19 "" "different slice range stays independent" "b.example"
 
   # Restore the overwritten objects so that the enabled phase and any rerun
-  # against a warm MinIO start from the checked-in fixture content.
+  # against a warm origin start from the checked-in fixture content.
   overwriteObject "${fixture_dir}/enabled.txt" "cache-bypass/enabled.txt"
   overwriteObject "${fixture_dir}/disabled.txt" "cache-bypass/disabled.txt"
   overwriteObject "${fixture_dir}/sliced.txt" "cache-bypass/sliced.txt"
@@ -289,9 +289,9 @@ else
   assertRangeGetEquals "/cache-bypass/sliced.txt" "${fixture_dir}/updated.txt" 0 9 "no-cache" "no-cache bypasses the slice cache"
   assertRangeGetEquals "/cache-bypass/sliced.txt" "${fixture_dir}/updated.txt" 0 9 "" "bypass refreshed the slice cache"
 
-  # Restore the overwritten object and bypass once more so that both MinIO
+  # Restore the overwritten object and bypass once more so that both the origin
   # and the slice cache end the phase holding the checked-in fixture content,
-  # keeping reruns against a warm gateway/MinIO deterministic.
+  # keeping reruns against a warm gateway/origin deterministic.
   overwriteObject "${fixture_dir}/sliced.txt" "cache-bypass/sliced.txt"
   assertRangeGetEquals "/cache-bypass/sliced.txt" "${fixture_dir}/sliced.txt" 0 9 "no-cache" "restored object re-primed into the slice cache"
 fi

--- a/test/integration/test_cache_ignore_headers.sh
+++ b/test/integration/test_cache_ignore_headers.sh
@@ -19,14 +19,14 @@
 # Integration tests for the PROXY_CACHE_IGNORE_HEADERS feature (GH-64). The
 # gateway must already be running with the feature configured; this script
 # seeds objects that carry a cache-defeating Cache-Control value, then issues
-# requests and mutates the objects in the MinIO backend to prove whether the
+# requests and mutates the objects in the S3 origin to prove whether the
 # gateway honored or ignored that header.
 #
 # The disabled phase is what reproduces GH-64: an origin that returns
 # 'Cache-Control: private, max-age=0' - the Google Cloud Storage default for
 # authenticated reads - makes NGINX treat every response as uncacheable, so
 # nothing is ever written to /var/cache/nginx/s3_proxy. That phase also keeps
-# the enabled phase honest: if MinIO ever stopped returning the header, the
+# the enabled phase honest: if the origin ever stopped returning the header, the
 # disabled phase would fail here rather than the enabled phase passing
 # vacuously.
 #
@@ -41,8 +41,8 @@ test_server=$1
 test_dir=$2
 phase=$3
 mc_cmd=$4
-minio_alias=$5
-minio_bucket=$6
+origin_alias=$5
+origin_bucket=$6
 
 test_fail_exit_code=2
 no_dep_exit_code=3
@@ -81,13 +81,13 @@ if ! [ -x "${mc_cmd}" ]; then
   exit ${no_dep_exit_code}
 fi
 
-if [ -z "${minio_alias}" ]; then
-  e "missing fifth parameter: mc alias of the MinIO backend"
+if [ -z "${origin_alias}" ]; then
+  e "missing fifth parameter: mc alias of the S3 origin"
   exit ${no_dep_exit_code}
 fi
 
-if [ -z "${minio_bucket}" ]; then
-  e "missing sixth parameter: name of the MinIO bucket"
+if [ -z "${origin_bucket}" ]; then
+  e "missing sixth parameter: name of the S3 origin bucket"
   exit ${no_dep_exit_code}
 fi
 
@@ -115,9 +115,9 @@ if [[ $checksum_cmd =~ \/md5$ ]]; then
   checksum_cmd="${checksum_cmd} -r"
 fi
 
-fixture_dir="${test_dir}/data/${minio_bucket}/cache-ignore-headers"
+fixture_dir="${test_dir}/data/${origin_bucket}/cache-ignore-headers"
 
-# Writes a local file to an object in the MinIO backend with the
+# Writes a local file to an object in the S3 origin with the
 # cache-defeating Cache-Control metadata attached. Used both to seed and to
 # mutate, so the header is present on every response the gateway sees - the
 # generic fixture upload in run_integration_tests.sh sets no metadata.
@@ -125,9 +125,9 @@ fixture_dir="${test_dir}/data/${minio_bucket}/cache-ignore-headers"
 putObjectWithCacheControl() {
   local_src="$1"
   object_key="$2"
-  echo "  Writing ${minio_bucket}/${object_key} from $(basename "${local_src}") with ${cache_control_attr}"
+  echo "  Writing ${origin_bucket}/${object_key} from $(basename "${local_src}") with ${cache_control_attr}"
   "${mc_cmd}" cp --attr "${cache_control_attr}" "${local_src}" \
-    "${minio_alias}/${minio_bucket}/${object_key}" > /dev/null
+    "${origin_alias}/${origin_bucket}/${object_key}" > /dev/null
 }
 
 # Asserts that a GET of <url_path> returns a body identical to <local_file>.

--- a/test/integration/test_directory_listing_pagination.sh
+++ b/test/integration/test_directory_listing_pagination.sh
@@ -24,9 +24,10 @@
 # every page ending in a truncated response must render a "Next page" link
 # whose marker is relative to the listed directory.
 #
-# Markers are treated as opaque: AWS returns the last key of the page as
-# NextMarker, but MinIO decorates it with an internal continuation hint
-# (e.g. 'e.txt[minio_cache:v2,return:]'), so assertions check that a marker
+# Markers are treated as opaque: AWS and RustFS return the last key of the
+# page as NextMarker, but some S3-compatible backends (MinIO, for example)
+# decorate it with an internal continuation hint such as
+# 'e.txt[minio_cache:v2,return:]', so assertions check that a marker
 # STARTS WITH the expected relative key and otherwise navigate with the
 # marker extracted from the page, exactly like a browsing client. All
 # expected strings are asserted in their percent-encoded (ASCII) form so the
@@ -124,10 +125,11 @@ next_marker() {
   sed -n 's/.*href="?marker=\([^"]*\)".*/\1/p' "${tmp_dir}/page.html"
 }
 
-# The backend decides the exact marker value (AWS: the last key; MinIO: the
-# last key plus an internal hint), but the marker must always begin with the
-# page's last entry relative to the listed directory - anything else means
-# the gateway leaked an internal prefix or the stylesheet mis-stripped it.
+# The backend decides the exact marker value (AWS/RustFS: the last key;
+# MinIO: the last key plus an internal hint), but the marker must always
+# begin with the page's last entry relative to the listed directory -
+# anything else means the gateway leaked an internal prefix or the
+# stylesheet mis-stripped it.
 assert_next_marker_starts_with() {
   expected_prefix=$1
   message=$2

--- a/test/integration/test_directory_listing_pagination.sh
+++ b/test/integration/test_directory_listing_pagination.sh
@@ -25,10 +25,9 @@
 # whose marker is relative to the listed directory.
 #
 # Markers are treated as opaque: AWS and RustFS return the last key of the
-# page as NextMarker, but some S3-compatible backends (MinIO, for example)
-# decorate it with an internal continuation hint such as
-# 'e.txt[minio_cache:v2,return:]', so assertions check that a marker
-# STARTS WITH the expected relative key and otherwise navigate with the
+# page as NextMarker, but some S3-compatible backends decorate it with an
+# internal continuation hint appended to the key, so assertions check that
+# a marker STARTS WITH the expected relative key and otherwise navigate with the
 # marker extracted from the page, exactly like a browsing client. All
 # expected strings are asserted in their percent-encoded (ASCII) form so the
 # assertions are safe on shells with broken UTF-8 handling.
@@ -126,7 +125,7 @@ next_marker() {
 }
 
 # The backend decides the exact marker value (AWS/RustFS: the last key;
-# MinIO: the last key plus an internal hint), but the marker must always
+# other backends may append an internal hint), but the marker must always
 # begin with the page's last entry relative to the listed directory -
 # anything else means the gateway leaked an internal prefix or the
 # stylesheet mis-stripped it.

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -21,7 +21,7 @@
 # by the GNUmakefile (make test-integration / make retest) - not intended to
 # be run directly, although doing so is harmless.
 #
-# The suite starts MinIO plus the gateway, seeds test data, then drives
+# The suite starts RustFS plus the gateway, seeds test data, then drives
 # test/integration/test_api.sh and test_cache_bypass.sh through a matrix of
 # gateway configurations. The entrypoint-script tests run first since they
 # only need the image, not the compose environment.
@@ -59,14 +59,16 @@ dynamic_credentials_compose_config="${test_dir}/docker-compose.dynamic-credentia
 secret_file_credentials_compose_config="${test_dir}/docker-compose.secret-file-credentials.yaml"
 test_compose_project="${COMPOSE_PROJECT:-ngt}"
 
-minio_server="http://localhost:9090"
-minio_user="AKIAIOSFODNN7EXAMPLE"
-minio_passwd="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-minio_name="${test_compose_project}_minio_1"
-minio_bucket="bucket-1"
+# The S3 origin is RustFS (see test/docker-compose.yaml); mc, used purely as
+# a generic S3 client, still talks to it for seeding and object mutation.
+s3_origin_server="http://localhost:9090"
+s3_origin_user="AKIAIOSFODNN7EXAMPLE"
+s3_origin_passwd="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+s3_origin_container="${test_compose_project}_rustfs_1"
+s3_origin_bucket="bucket-1"
 test_tls_cert_dir="${TMPDIR:-/tmp}/nginx-s3-gateway-${test_compose_project}-tls"
 test_secrets_dir="${TMPDIR:-/tmp}/nginx-s3-gateway-${test_compose_project}-secrets"
-minio_mc_args=()
+mc_extra_args=()
 
 DOCKER="${DOCKER:-docker}"
 NGINX_TYPE="${NGINX_TYPE:-oss}"
@@ -260,27 +262,30 @@ compose_secret_file_credentials() {
 }
 
 # Configure the compose environment and mc/curl endpoints for an HTTP or
-# HTTPS MinIO origin. Kept as one function so the two origin modes cannot
+# HTTPS S3 origin. Kept as one function so the two origin modes cannot
 # drift apart when a new TEST_* knob is added.
 # set_test_origin <http|https>
 set_test_origin() {
   origin_proto="$1"
-  export TEST_S3_SERVER="minio"
+  export TEST_S3_SERVER="rustfs"
   export TEST_S3_SERVER_PORT="9000"
   export TEST_S3_SERVER_PROTO="${origin_proto}"
   export TEST_S3_TRUSTED_CERT_PATH="/etc/ssl/certs/ca-certificates.crt"
-  export TEST_MINIO_SERVER_PROTO="${origin_proto}"
+  export TEST_S3_ORIGIN_PROTO="${origin_proto}"
   export TEST_TLS_CERT_DIR="${test_tls_cert_dir}"
   export TEST_PROXY_CACHE_SLICE_SIZE="1m"
-  minio_server="${origin_proto}://localhost:9090"
+  s3_origin_server="${origin_proto}://localhost:9090"
   if [ "${origin_proto}" = "https" ]; then
-    # Mount point of the generated test certificates inside the MinIO
-    # container; MinIO serves TLS when its certs dir contains a key pair.
-    export TEST_MINIO_CERTS_DIR="/tmp/test-certs"
-    minio_mc_args=(--insecure)
+    # Mount point of the generated test certificates inside the origin
+    # container. RustFS serves TLS only when RUSTFS_TLS_PATH names a
+    # directory holding rustfs_cert.pem/rustfs_key.pem - and refuses to
+    # start when the path is set but missing or empty, so the HTTP branch
+    # must leave the variable empty rather than point at a placeholder.
+    export TEST_S3_TLS_PATH="/tls"
+    mc_extra_args=(--insecure)
   else
-    export TEST_MINIO_CERTS_DIR="/root/.minio/certs"
-    minio_mc_args=()
+    export TEST_S3_TLS_PATH=""
+    mc_extra_args=()
   fi
 }
 
@@ -303,18 +308,22 @@ generate_tls_test_certs() {
         -keyout /certs/ca.key -out /certs/ca.crt -days 1 \
         -subj "/CN=nginx-s3-gateway test CA" >/dev/null 2>&1
       openssl req -newkey rsa:2048 -nodes \
-        -keyout /certs/private.key -out /certs/server.csr \
-        -subj "/CN=minio" >/dev/null 2>&1
+        -keyout /certs/rustfs_key.pem -out /certs/server.csr \
+        -subj "/CN=rustfs" >/dev/null 2>&1
       printf "%s\n" \
         "basicConstraints=CA:FALSE" \
         "keyUsage=digitalSignature,keyEncipherment" \
         "extendedKeyUsage=serverAuth" \
-        "subjectAltName=DNS:minio,DNS:bucket-1.minio" > /certs/server.ext
+        "subjectAltName=DNS:rustfs,DNS:bucket-1.rustfs" > /certs/server.ext
       openssl x509 -req -in /certs/server.csr \
         -CA /certs/ca.crt -CAkey /certs/ca.key -CAcreateserial \
-        -out /certs/public.crt -days 1 -extfile /certs/server.ext >/dev/null 2>&1
-      chmod 0644 /certs/ca.crt /certs/public.crt
-      chmod 0600 /certs/ca.key /certs/private.key
+        -out /certs/rustfs_cert.pem -days 1 -extfile /certs/server.ext >/dev/null 2>&1
+      chmod 0644 /certs/ca.crt /certs/rustfs_cert.pem
+      # The throwaway server key must be readable by the RustFS process,
+      # which runs as uid 10001 while this container generates the files as
+      # root; the CA key is never read inside a container so it stays 0600.
+      chmod 0644 /certs/rustfs_key.pem
+      chmod 0600 /certs/ca.key
     '
 }
 
@@ -331,19 +340,20 @@ integration_test_data() {
   # COMPOSE_COMPATIBILITY=true Supports older style compose filenames with _ vs -
   COMPOSE_COMPATIBILITY=true compose up -d
 
-  seed_minio_data
+  seed_origin_data
 }
 
-seed_minio_data() {
+seed_origin_data() {
 
-  # Hit minio's health check end point to see if it has started up
+  # Hit the origin's health check end point to see if it has started up
   for (( i=1; i<=3; i++ ))
   do
-    echo "Querying minio server to see if it is ready"
-    # `|| true` keeps errexit from aborting the retry loop when minio is not
-    # listening yet (curl exits 7 on connection refused but still prints 000).
-    minio_is_up="$(${curl_cmd} --insecure -s -o /dev/null -w '%{http_code}' "${minio_server}"/minio/health/cluster || true)"
-    if [ "${minio_is_up}" = "200" ]; then
+    echo "Querying the S3 origin to see if it is ready"
+    # `|| true` keeps errexit from aborting the retry loop when the origin is
+    # not listening yet (curl exits 7 on connection refused but still prints
+    # 000).
+    origin_is_up="$(${curl_cmd} --insecure -s -o /dev/null -w '%{http_code}' "${s3_origin_server}"/health || true)"
+    if [ "${origin_is_up}" = "200" ]; then
       break
     else
       sleep 2
@@ -353,17 +363,19 @@ seed_minio_data() {
   p "Adding test data to container"
   # ${arr[@]+...} keeps the empty-array expansion from tripping `set -o
   # nounset` on bash < 4.4 (macOS ships bash 3.2).
-  "${mc_cmd}" alias set ${minio_mc_args[@]+"${minio_mc_args[@]}"} "$minio_name" "$minio_server" "$minio_user" "$minio_passwd"
+  "${mc_cmd}" alias set ${mc_extra_args[@]+"${mc_extra_args[@]}"} "$s3_origin_container" "$s3_origin_server" "$s3_origin_user" "$s3_origin_passwd"
   # --ignore-existing keeps a bucket left behind by an aborted previous run
   # (compose containers survive a failed teardown) from failing the seeding
   # step under errexit on every subsequent run.
-  "${mc_cmd}" mb ${minio_mc_args[@]+"${minio_mc_args[@]}"} --ignore-existing "$minio_name/$minio_bucket"
-  echo "Copying contents of ${test_dir}/data/$minio_bucket to Docker container $minio_name"
-  for file in "${test_dir}/data/$minio_bucket"/*; do
-    "${mc_cmd}" cp ${minio_mc_args[@]+"${minio_mc_args[@]}"} -r "${file}" "$minio_name/$minio_bucket"
+  "${mc_cmd}" mb ${mc_extra_args[@]+"${mc_extra_args[@]}"} --ignore-existing "$s3_origin_container/$s3_origin_bucket"
+  echo "Copying contents of ${test_dir}/data/$s3_origin_bucket to Docker container $s3_origin_container"
+  for file in "${test_dir}/data/$s3_origin_bucket"/*; do
+    "${mc_cmd}" cp ${mc_extra_args[@]+"${mc_extra_args[@]}"} -r "${file}" "$s3_origin_container/$s3_origin_bucket"
   done
-  echo "Docker diff output:"
-  "${docker_cmd}" diff "$minio_name"
+  # RustFS declares VOLUME /data, so `docker diff` (which the old MinIO
+  # seeding printed here) would show nothing; list the seeded objects instead.
+  echo "Seeded bucket contents:"
+  "${mc_cmd}" ls ${mc_extra_args[@]+"${mc_extra_args[@]}"} -r "$s3_origin_container/$s3_origin_bucket"
 }
 
 integration_test_listen_directives() {
@@ -494,8 +506,8 @@ integration_test_cache_bypass() {
   wait_for_gateway
 
   p "Starting cache bypass tests (phase: ${bypass_phase})"
-  echo "  test/integration/test_cache_bypass.sh \"$test_server\" \"$test_dir\" ${bypass_phase} \"${mc_cmd}\" \"${minio_name}\" \"${minio_bucket}\""
-  bash "${test_dir}/integration/test_cache_bypass.sh" "${test_server}" "${test_dir}" "${bypass_phase}" "${mc_cmd}" "${minio_name}" "${minio_bucket}"
+  echo "  test/integration/test_cache_bypass.sh \"$test_server\" \"$test_dir\" ${bypass_phase} \"${mc_cmd}\" \"${s3_origin_container}\" \"${s3_origin_bucket}\""
+  bash "${test_dir}/integration/test_cache_bypass.sh" "${test_server}" "${test_dir}" "${bypass_phase}" "${mc_cmd}" "${s3_origin_container}" "${s3_origin_bucket}"
 }
 
 integration_test_cache_ignore_headers() {
@@ -523,8 +535,8 @@ integration_test_cache_ignore_headers() {
   wait_for_gateway
 
   p "Starting cache ignore headers tests (phase: ${ignore_phase})"
-  echo "  test/integration/test_cache_ignore_headers.sh \"$test_server\" \"$test_dir\" ${ignore_phase} \"${mc_cmd}\" \"${minio_name}\" \"${minio_bucket}\""
-  bash "${test_dir}/integration/test_cache_ignore_headers.sh" "${test_server}" "${test_dir}" "${ignore_phase}" "${mc_cmd}" "${minio_name}" "${minio_bucket}"
+  echo "  test/integration/test_cache_ignore_headers.sh \"$test_server\" \"$test_dir\" ${ignore_phase} \"${mc_cmd}\" \"${s3_origin_container}\" \"${s3_origin_bucket}\""
+  bash "${test_dir}/integration/test_cache_ignore_headers.sh" "${test_server}" "${test_dir}" "${ignore_phase}" "${mc_cmd}" "${s3_origin_container}" "${s3_origin_bucket}"
 }
 
 integration_test_cors() {
@@ -603,7 +615,7 @@ assert_gateway_logs_contain() {
 start_tls_gateway() {
   trusted_cert_path=$1
   tls_s3_style=${2:-${S3_STYLE:-virtual-v2}}
-  tls_s3_server=${3:-minio}
+  tls_s3_server=${3:-rustfs}
   export TEST_S3_TRUSTED_CERT_PATH="${trusted_cert_path}"
   export TEST_S3_SERVER="${tls_s3_server}"
   COMPOSE_COMPATIBILITY=true S3_STYLE="${tls_s3_style}" AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=1 PROVIDE_INDEX_PAGE=1 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=1 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose up -d
@@ -637,11 +649,11 @@ integration_test_proxy_ssl() {
   compose stop nginx-s3-gateway
 
   p "Verifying HTTPS S3 origin hostname validation"
-  start_tls_gateway "/etc/nginx/test-certs/ca.crt" "path" "minio"
+  start_tls_gateway "/etc/nginx/test-certs/ca.crt" "path" "rustfs"
   assert_request_status 200 "trusted path-style origin" "${test_server}/a.txt"
 
   compose stop nginx-s3-gateway
-  start_tls_gateway "/etc/nginx/test-certs/ca.crt" "path" "minio-mismatch"
+  start_tls_gateway "/etc/nginx/test-certs/ca.crt" "path" "rustfs-mismatch"
   assert_request_not_status 200 "mismatched origin hostname" "${test_server}/a.txt"
   assert_gateway_logs_contain "upstream SSL certificate does not match" "mismatched origin hostname verification"
 }
@@ -656,7 +668,7 @@ integration_test_dynamic_credentials() {
 
   COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose_dynamic_credentials up -d
   wait_for_gateway
-  seed_minio_data
+  seed_origin_data
 
   assert_request_status 200 "dynamic credentials first object request" "${test_server}/a.txt"
 
@@ -693,13 +705,13 @@ integration_test_secret_file_credentials() {
   # was killed before finish() could clean up would make the redirections below
   # fail with EACCES - even for their own owner - and abort the whole suite.
   rm -f "${test_secrets_dir}"/aws_access_key_id "${test_secrets_dir}"/aws_secret_access_key
-  printf '%s\n' "${minio_user}" > "${test_secrets_dir}/aws_access_key_id"
-  printf '%s\n' "${minio_passwd}" > "${test_secrets_dir}/aws_secret_access_key"
+  printf '%s\n' "${s3_origin_user}" > "${test_secrets_dir}/aws_access_key_id"
+  printf '%s\n' "${s3_origin_passwd}" > "${test_secrets_dir}/aws_secret_access_key"
   chmod 0444 "${test_secrets_dir}"/aws_*
 
   COMPOSE_COMPATIBILITY=true AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=0 PROVIDE_INDEX_PAGE=0 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=0 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose_secret_file_credentials up -d
   wait_for_gateway
-  seed_minio_data
+  seed_origin_data
 
   # A signed request only succeeds if the credentials made it out of the files
   # and through the nginx.conf env allowlist into the njs modules - a missing
@@ -713,7 +725,7 @@ integration_test_secret_file_credentials() {
   # failing the pipeline - and so passing this check - exactly when the secret
   # is found.
   gateway_env="$(compose_secret_file_credentials exec -T nginx-s3-gateway env 2>&1)"
-  if grep -qF "${minio_passwd}" <<< "${gateway_env}"; then
+  if grep -qF "${s3_origin_passwd}" <<< "${gateway_env}"; then
     e "FAIL [secret file credentials]: the secret access key must not be in the container environment"
     exit "$test_fail_exit_code"
   fi
@@ -736,7 +748,7 @@ finish() {
 
   p "Cleaning up Docker compose environment"
   compose_dynamic_credentials down --volumes --remove-orphans || true
-  "${mc_cmd}" alias rm "$minio_name" || true
+  "${mc_cmd}" alias rm "$s3_origin_container" || true
   # Try a plain removal first: the cert dir is created by the invoking user,
   # so its entries are usually unlinkable without root even though the files
   # themselves are root-owned. Only spin up a root container (1-2s, and

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -167,7 +167,7 @@ else
   e "required dependency not found: mc not found in the path or not executable"
   exit ${no_dep_exit_code}
 fi
-e "Using MinIO Client: ${mc_cmd}"
+e "Using mc (S3 test client): ${mc_cmd}"
 
 # Blocks until the gateway answers an HTTP request, replacing the external
 # wait-for-it dependency.
@@ -372,8 +372,8 @@ seed_origin_data() {
   for file in "${test_dir}/data/$s3_origin_bucket"/*; do
     "${mc_cmd}" cp ${mc_extra_args[@]+"${mc_extra_args[@]}"} -r "${file}" "$s3_origin_container/$s3_origin_bucket"
   done
-  # RustFS declares VOLUME /data, so `docker diff` (which the old MinIO
-  # seeding printed here) would show nothing; list the seeded objects instead.
+  # RustFS declares VOLUME /data, so `docker diff` (which the seeding step
+  # once printed here) would show nothing; list the seeded objects instead.
   echo "Seeded bucket contents:"
   "${mc_cmd}" ls ${mc_extra_args[@]+"${mc_extra_args[@]}"} -r "$s3_origin_container/$s3_origin_bucket"
 }

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -508,7 +508,7 @@ async function testEcsCredentialRetrieval() {
             throw `No or wrong ECS credentials fetch URL recorded: ${recordedUrl}`;
         }
 
-        /* The integration ECS mock cannot serve a Token (MinIO rejects
+        /* The integration ECS mock cannot serve a Token (the S3 origin rejects
            fabricated session tokens), so the Token -> sessionToken -> cache
            seam is pinned here instead. */
         var cached = JSON.parse(globalThis.ngx.shared.instance_credential_cache

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -737,8 +737,8 @@ function testS3DirQueryParams() {
         check('/b/c/', 'GET', undefined, 'delimiter=%2F&prefix=b%2Fc%2F');
         // Values past S3's 32-bit max-keys range draw 400 InvalidArgument
         // from AWS on every listing, so they degrade like any other invalid
-        // value. Only a unit test can pin this: MinIO parses max-keys as
-        // 64-bit and would accept the oversized value.
+        // value. Only a unit test can pin this: some S3-compatible origins
+        // parse max-keys as 64-bit and would accept the oversized value.
         process.env['DIRECTORY_LISTING_PAGE_SIZE'] = '2147483648';
         check('/b/c/', 'GET', undefined, 'delimiter=%2F&prefix=b%2Fc%2F');
         // The 32-bit boundary value itself is still accepted.


### PR DESCRIPTION
## What

Replaces the pinned MinIO origin (`RELEASE.2023-06-09`) with RustFS
(`rustfs/rustfs:1.0.0-rc.3`, pinned by digest) in the integration test stack.
`mc` stays on as the generic S3 seeding/mutation client — RustFS also exposes
a MinIO-admin-compatible API, so `mc admin` tooling keeps working.

## Why

The follow-up AssumeRole credential feature (#122) needs an origin whose STS
`AssumeRole` endpoint cryptographically validates SigV4 signatures and
enforces the issued temporary credentials on subsequent S3 requests — the
strongest possible end-to-end signal for new signing code. MinIO has such an
endpoint too, but the pin is three years stale (and AGPL), while RustFS is
Apache-2.0 and actively maintained. LocalStack was evaluated and ruled out:
its community edition was discontinued in March 2026 (account token required)
and it never verified request signatures.

## Validated before migrating (spike against the pinned image)

- SigV2 header auth end-to-end: path **and** virtual-host style, including
  V2-signed `ListObjectsV1` with markers — all 7 SigV2 legs stay live.
- Byte-for-byte round-trips of the reserved-character / Unicode fixture keys
  (`b/c/=`, `a/%@!*()=$#^&|.txt`, `системы/%bad%file%name%`, …); a missing
  `=`-suffixed key returns 404, not 403 (rustfs#2477 is fixed in this tag).
- AWS-faithful `ListObjectsV1`: exact `max-keys` truncation, plain-key
  `NextMarker` (no decoration), `IsTruncated=false` with no marker on an
  exactly-full final page, `%F4%8F%BF%BF` past-the-end → empty page.
- `Cache-Control` object metadata stored via `mc cp --attr` and echoed on GET.
- Range → 206 with `Content-Range`; TLS serving; HEAD on a directory → 404.

## RustFS behaviors the stack now encodes

- `RUSTFS_SERVER_DOMAINS` must list **both** `rustfs:9000,rustfs`: bucket
  parsing suffix-matches the raw Host header, and `virtual-v2` sends
  `Host: bucket-1.rustfs:9000` while `virtual` sends `Host: bucket-1.rustfs`.
- `RUSTFS_TLS_PATH` is **fatal at startup** when set to a missing or empty
  directory, so the compose default is an empty value (plain HTTP) and only
  the proxy_ssl leg points it at the cert mount. The generated server pair is
  `rustfs_cert.pem`/`rustfs_key.pem`, chmod 0644 because RustFS runs as uid
  10001 (MinIO ran as root).
- Keys containing raw CR/LF bytes are rejected with 400 where AWS/MinIO
  answer 404, so the header-injection redirect assertion became
  `assertRedirectSafeFromHeaderInjection`: the append-slash redirect is
  optional for such keys, but an injected header or a wrongly-encoded
  `Location` still fails the test.
- Seeding lists the bucket with `mc ls -r` instead of `docker diff`, which
  shows nothing now that the origin declares `VOLUME /data`.

The runner's `minio_*` globals were renamed to backend-neutral `s3_origin_*`
in the same pass, since nearly every use changed meaning anyway.
`test-settings.minio-local` is dead-path legacy input to the deprecated
`test.sh` and is deliberately untouched.

## Testing

`make lint` plus the full suite locally on all three addressing styles
(`make retest S3_STYLE=virtual-v2|virtual|path`) and the unprivileged
variant — every leg green, including the 7 SigV2 legs proven by
`assert_gateway_sig_version`, both pagination legs, the 4 cache legs, CORS,
proxy_ssl (trusted / untrusted / hostname-mismatch against
`rustfs-mismatch`), and the dynamic- and secret-file-credential legs.
