### PR TITLE
fix: single-flight the credential refresh at expiry (#591)

### DIFF
--- a/.claude/skills/smoke-test/references/regressions.md
+++ b/.claude/skills/smoke-test/references/regressions.md
@@ -9,6 +9,39 @@ against them before calling anything a new defect. Probe conventions are the sam
 Each set names its fix commit; `git log <commit> -1` shows the full
 context if a probe's intent is unclear.
 
+## #591 — single-flight credential refresh at expiry
+
+Fix commit: the commit that added this entry. Every concurrent request
+whose cached credentials had crossed the 4.5-minute expiry margin
+independently walked the provider ladder (N requests → N provider
+calls). Now one request per 30s window wins an atomic `add()` on the
+`credential_refresh_lock` shared-dict zone and refreshes; the rest are
+served with the still-valid cached credentials. A cold start (empty
+cache) still blocking-fetches in every request, and an elected
+refresher whose fetch fails serves the cached set with a 200 instead
+of a 500. Use distinct object paths per burst so the proxy cache
+cannot mask the auth_request path.
+
+1. Both flavors: the container's
+   `/etc/nginx/conf.d/credential_refresh_lock.conf` declares
+   `js_shared_dict_zone zone=credential_refresh_lock:32k timeout=30s;`
+   and startup logs contain no `[emerg]` and no
+   `credential_refresh_lock is unavailable`.
+2. Dynamic-credentials overlay (ECS mock), cold start: a concurrent
+   GET burst → all 200 and the DEBUG logs contain at least one
+   `requesting new ones` line (cold start still fetches).
+3. In-margin single flight: overlay the ECS credentials mock with a
+   *literal* `Expiration` ~6 minutes ahead written at stack-creation
+   time, warm the cache with one request, wait until inside
+   `Expiration − 4.5min`, then burst concurrent GETs → all 200 and at
+   most one new `requesting new ones` line per 30-second window (was:
+   one per request).
+4. Failure absorption: same overlay, stop the credentials mock once
+   in-margin, burst → still all 200 (the elected refresher serves the
+   cached set; the failure is logged at error level). Restart the
+   mock → a successful refresh lands within ~30s (lock timeout
+   re-arms the election).
+
 ## #88 — duplicate literal slashes collapse before signing and proxying
 
 Fix commit: the commit that added this entry. The raw `$request_uri`

--- a/common/etc/nginx/conf.d/credential_refresh_lock.conf
+++ b/common/etc/nginx/conf.d/credential_refresh_lock.conf
@@ -1,0 +1,21 @@
+# Single-flight sentinel for credential refresh (GH-591): when the cached
+# credentials enter the 4.5-minute pre-expiry refresh margin, exactly one
+# request per timeout window wins the atomic add() in fetchCredentials and
+# walks the credential provider ladder; every other request keeps serving
+# the still-valid cached credentials.
+#
+# The zone is shared by both flavors from this single declaration so the
+# locking behavior cannot drift between them: OSS and Plus cache the
+# credentials themselves differently (njs shared dictionary vs keyval), but
+# keyval has no atomic add(), so the sentinel is an njs shared dictionary in
+# both - the njs module is already loaded for the gateway's js_content
+# handlers.
+#
+# This is deliberately a SEPARATE zone from the instance_credential_cache
+# zone: the sentinel needs a timeout (a crashed, hung, or failed refresher
+# must self-release) while the credential entry must never be evicted by
+# one, and njs zone timeouts apply to every entry in a zone. 30s comfortably
+# outlives a healthy provider fetch and re-arms a failed refresh up to nine
+# times inside the refresh margin. The zone holds a single one-byte entry;
+# 32k is the slab-zone minimum.
+js_shared_dict_zone zone=credential_refresh_lock:32k timeout=30s;

--- a/common/etc/nginx/include/awscredentials.js
+++ b/common/etc/nginx/include/awscredentials.js
@@ -128,6 +128,40 @@ const INSTANCE_CREDENTIAL_CACHE_KEY = 'instance_credentials';
  */
 const INSTANCE_CREDENTIAL_CACHE_ZONE = 'instance_credential_cache';
 
+/**
+ * Name of the njs shared dictionary zone used as the single-flight sentinel
+ * for credential refreshes (GH-591). Unlike INSTANCE_CREDENTIAL_CACHE_ZONE
+ * this zone is declared WITH a timeout, so a crashed, hung, or failed
+ * refresher's sentinel entry self-releases. Must byte-match the zone
+ * declared for both flavors in
+ * common/etc/nginx/conf.d/credential_refresh_lock.conf.
+ *
+ * Providers issue credentials valid for at least another 5 minutes while
+ * maxValidityOffsetMs is 4.5 minutes, so a residual sentinel (held at most
+ * for the zone timeout of 30s after a successful refresh) can never gate a
+ * legitimately needed refresh. Revisit the zone timeout if
+ * maxValidityOffsetMs is ever raised toward 5 minutes.
+ * @type {string}
+ */
+const CREDENTIAL_REFRESH_LOCK_ZONE = 'credential_refresh_lock';
+
+/**
+ * The single key inserted into CREDENTIAL_REFRESH_LOCK_ZONE. Whichever
+ * request atomically adds it is elected to walk the credential provider
+ * ladder for the current refresh window.
+ * @type {string}
+ */
+const CREDENTIAL_REFRESH_LOCK_KEY = 'credential_refresh_in_flight';
+
+/**
+ * Value stored under CREDENTIAL_REFRESH_LOCK_KEY. Only the key's presence
+ * matters to the atomic add() election, but the zone's default type is
+ * string, so some string must be written; tests reference this constant
+ * rather than repeating the literal.
+ * @type {string}
+ */
+const CREDENTIAL_REFRESH_LOCK_VALUE = '1';
+
 
 /**
  * Get the current session token from either the instance profile credential
@@ -336,6 +370,27 @@ function _writeCredentialsToSharedDict(credentials) {
 }
 
 /**
+ * Look up an njs shared dictionary zone, returning undefined when the njs
+ * environment or the zone is absent (e.g. the njs CLI, or a custom NGINX
+ * configuration missing the declaration). Callers choose their own failure
+ * mode: _instanceCredentialSharedDict throws (the credential cache is
+ * required), _tryAcquireCredentialRefreshLock fails open (the sentinel is
+ * an optimization).
+ *
+ * @param zoneName {string} name of the js_shared_dict_zone to look up
+ * @returns {NgxSharedDict|undefined} the shared dictionary, or undefined when unavailable
+ * @private
+ */
+function _sharedDictOrUndefined(zoneName) {
+    if (typeof ngx === 'undefined' || !("shared" in ngx) ||
+        !(zoneName in ngx.shared)) {
+        return undefined;
+    }
+
+    return ngx.shared[zoneName];
+}
+
+/**
  * Get the OSS shared dictionary used to cache temporary credentials.
  *
  * The OSS image configures this zone with js_shared_dict_zone. Keeping the
@@ -346,12 +401,80 @@ function _writeCredentialsToSharedDict(credentials) {
  * @private
  */
 function _instanceCredentialSharedDict() {
-    if (typeof ngx === 'undefined' || !("shared" in ngx) ||
-        !(INSTANCE_CREDENTIAL_CACHE_ZONE in ngx.shared)) {
+    const dict = _sharedDictOrUndefined(INSTANCE_CREDENTIAL_CACHE_ZONE);
+    if (dict === undefined) {
         throw `NGINX shared dictionary ${INSTANCE_CREDENTIAL_CACHE_ZONE} is unavailable`;
     }
 
-    return ngx.shared[INSTANCE_CREDENTIAL_CACHE_ZONE];
+    return dict;
+}
+
+/**
+ * Try to acquire the single-flight sentinel that elects one request to
+ * refresh credentials inside the refresh margin while every other request
+ * keeps serving the still-valid cached credentials (GH-591).
+ *
+ * The sentinel is an atomic shared-dictionary add(): it succeeds for exactly
+ * one request per zone-timeout window across all workers. The entry is
+ * deliberately never deleted - after a successful refresh the fresh
+ * expiration keeps requests on the fast path anyway, and after a failed
+ * refresh the zone timeout re-arms the next attempt at most once per window
+ * while the cached credentials remain valid.
+ *
+ * Unlike _instanceCredentialSharedDict this fails OPEN (returns true) when
+ * the zone is missing or add() throws: the sentinel is an optimization, and
+ * failing closed would mean no request ever refreshes, turning a merely
+ * missing zone into an outage at credential expiry. Failing open degrades to
+ * the pre-GH-591 behavior of every request refreshing.
+ *
+ * @param r {NginxHTTPRequest} HTTP request object (used for debug logging)
+ * @returns {boolean} true when this request must perform the refresh
+ * @private
+ */
+function _tryAcquireCredentialRefreshLock(r) {
+    const lockDict = _sharedDictOrUndefined(CREDENTIAL_REFRESH_LOCK_ZONE);
+    if (lockDict === undefined) {
+        utils.debug_log(r, `NGINX shared dictionary ${CREDENTIAL_REFRESH_LOCK_ZONE} is unavailable, refreshing without single-flight coordination`);
+        return true;
+    }
+    try {
+        /* No per-item timeout is passed: the zone-level timeout governs, and
+           a per-item timeout would throw a TypeError on any zone declared
+           without one (a hazard for custom configurations). The value must
+           be a string - the zone's default type is string, and a number
+           would throw a TypeError too. */
+        return lockDict.add(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    } catch (e) {
+        /* SharedMemoryError (zone full) or any other failure: refresh
+           anyway - the worst case is the pre-GH-591 herd. */
+        utils.debug_log(r, `Could not acquire the credential refresh lock, refreshing anyway: ${e}`);
+        return true;
+    }
+}
+
+/**
+ * Answer a failed credential fetch: when the cached credentials are still
+ * valid at failure time (this request was elected refresher inside the
+ * refresh margin) the request is served from the cache with a 200 - the
+ * failure has already been logged by the caller and the sentinel zone
+ * timeout re-arms the next refresh attempt - otherwise the failure surfaces
+ * as a 500 exactly as on a cold start (GH-591). The deadline is re-checked
+ * against a live clock here because a slow provider fetch (e.g. the IMDSv1
+ * token-timeout fallback) can outlast the remaining validity when the
+ * refresh started late in the margin, and serving credentials that expired
+ * during the fetch would turn the 500 into an S3 signature failure.
+ *
+ * @param r {NginxHTTPRequest} HTTP request object
+ * @param cachedValidUntilMs {number} epoch ms until which the cached credentials stay valid; 0 when none
+ * @private
+ */
+function _returnCredentialFetchFailure(r, cachedValidUntilMs) {
+    if (new Date().getTime() < cachedValidUntilMs) {
+        utils.debug_log(r, 'Credential refresh failed; serving still-valid cached credentials');
+        r.return(200);
+        return;
+    }
+    r.return(500);
 }
 
 /**
@@ -397,23 +520,53 @@ async function fetchCredentials(r) {
         return;
     }
 
+    /* Millisecond deadline until which the cached credentials stay valid
+       while the provider ladder below runs (0 when nothing valid is
+       cached), so a failed refresh can be answered from the cache instead
+       of surfacing a 500 for an outage the refresh margin exists to absorb
+       (GH-591). A deadline rather than a boolean: the provider fetch can
+       outlast the remaining validity, so usability must be re-checked at
+       failure time. */
+    let cachedValidUntilMs = 0;
+
     if (current) {
         // If AWS returns a Unix timestamp it will be in seconds, but in Date constructor we should provide timestamp in milliseconds
         // In some situations (including EC2 and Fargate) current.expiration will be an RFC 3339 string - see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
-        const expireAt = typeof current.expiration == 'number' ? current.expiration * 1000 : current.expiration
-        const exp = new Date(expireAt).getTime() - maxValidityOffsetMs;
+        const expireAtValue = typeof current.expiration == 'number' ?
+            current.expiration * 1000 : current.expiration;
+        const expireAtMs = new Date(expireAtValue).getTime();
+        const refreshAtMs = expireAtMs - maxValidityOffsetMs;
         /* Use a live clock rather than NOW: NOW is stable per njs VM context
            for signature consistency, so it goes stale for expiry checks
            whenever module scope outlives a single request. */
-        if (new Date().getTime() < exp) {
+        const nowMs = new Date().getTime();
+        if (nowMs < refreshAtMs) {
             r.return(200);
             return;
+        }
+        /* Inside the refresh margin the cached credentials are still valid,
+           so exactly one request needs to walk the provider ladder: the
+           atomic sentinel elects it and every other request answers from
+           the cache (GH-591). Unparseable expirations (both comparisons
+           against NaN are false) and truly expired credentials skip the
+           election and refresh unconditionally, exactly like a cold start -
+           nothing valid is left to serve. */
+        if (nowMs < expireAtMs) {
+            if (!_tryAcquireCredentialRefreshLock(r)) {
+                r.return(200);
+                return;
+            }
+            cachedValidUntilMs = expireAtMs;
         }
     }
 
     let credentials;
 
-    utils.debug_log(r, 'Cached credentials are expired or not present, requesting new ones');
+    /* Both branches keep the 'requesting new ones' marker that the smoke
+       tests grep for (see .claude/skills/smoke-test/references/regressions.md). */
+    utils.debug_log(r, cachedValidUntilMs !== 0 ?
+        'Cached credentials are within the refresh margin, requesting new ones' :
+        'Cached credentials are expired or not present, requesting new ones');
 
     /* AssumeRole leads the ladder: it is the only provider reachable while
        static credentials are configured (matching the AWS SDKs, where
@@ -423,11 +576,12 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchAssumeRoleCredentials(r, staticCredentials);
         } catch (e) {
-            /* A failing STS call turns every request into a 500, so surface
-               it at error level rather than only under DEBUG - the same
-               contract as the cache read/write failures above and below. */
+            /* A failing STS call turns every request into a 500 once no
+               valid cached credentials remain (GH-591), so surface it at
+               error level rather than only under DEBUG - the same contract
+               as the cache read/write failures above and below. */
             r.error(`Could not assume role using static credentials: ${e}`);
-            r.return(500);
+            _returnCredentialFetchFailure(r, cachedValidUntilMs);
             return;
         }
     }
@@ -437,8 +591,12 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchEcsRoleCredentials(uri);
         } catch (e) {
-            utils.debug_log(r, `Could not load ECS task role credentials: ${e}`);
-            r.return(500);
+            /* Same error-level contract as the AssumeRole and cache
+               read/write failures: this either 500s the request or absorbs
+               a refresh failure the operator must be able to see without
+               DEBUG (GH-591). */
+            r.error(`Could not load ECS task role credentials: ${e}`);
+            _returnCredentialFetchFailure(r, cachedValidUntilMs);
             return;
         }
     }
@@ -446,8 +604,8 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchWebIdentityCredentials(r)
         } catch (e) {
-            utils.debug_log(r, `Could not assume role using web identity: ${e}`);
-            r.return(500);
+            r.error(`Could not assume role using web identity: ${e}`);
+            _returnCredentialFetchFailure(r, cachedValidUntilMs);
             return;
         }
     } 
@@ -455,26 +613,27 @@ async function fetchCredentials(r) {
         try {
             credentials = await _fetchEKSPodIdentityCredentials(r)
         } catch (e) {
-            utils.debug_log(r, `Could not assume role using EKS pod identity: ${e}`);
-            r.return(500);
+            r.error(`Could not assume role using EKS pod identity: ${e}`);
+            _returnCredentialFetchFailure(r, cachedValidUntilMs);
             return;
         }
     } else {
         try {
             credentials = await _fetchEC2RoleCredentials(r);
         } catch (e) {
-            utils.debug_log(r, `Could not load EC2 task role credentials: ${e}`);
-            r.return(500);
+            r.error(`Could not load EC2 task role credentials: ${e}`);
+            _returnCredentialFetchFailure(r, cachedValidUntilMs);
             return;
         }
     }
     try {
         writeCredentials(r, credentials);
     } catch (e) {
-        /* Cache write failures also 500 every request, so they too must be
-           visible at the default error log level, not only under DEBUG. */
+        /* Cache write failures also 500 every request once no valid cached
+           credentials remain (GH-591), so they too must be visible at the
+           default error log level, not only under DEBUG. */
         r.error(`Could not write credentials: ${e}`);
-        r.return(500);
+        _returnCredentialFetchFailure(r, cachedValidUntilMs);
         return;
     }
     r.return(200);
@@ -919,6 +1078,8 @@ function Now() {
 }
 
 export default {
+    CREDENTIAL_REFRESH_LOCK_KEY,
+    CREDENTIAL_REFRESH_LOCK_VALUE,
     INSTANCE_CREDENTIAL_CACHE_KEY,
     Now,
     fetchCredentials,
@@ -931,5 +1092,7 @@ export default {
     _getStsEndpoint,
     _parseAssumeRoleResponse,
     _parseStsEndpointUrl,
-    _readStaticCredentials
+    _readStaticCredentials,
+    _returnCredentialFetchFailure,
+    _tryAcquireCredentialRefreshLock
 }

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -644,7 +644,8 @@ AWS_SIGS_VERSION=4
 On the first proxied request the gateway sends a SigV4-signed
 [`AssumeRole`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) call (a form-encoded `POST`,
 exactly as the AWS SDKs send it) to the STS endpoint, caches the returned temporary credentials in memory (never on
-disk), and signs S3 requests with them. The credentials are refreshed shortly before they expire. Notes:
+disk), and signs S3 requests with them. The credentials are refreshed shortly before they expire by a single elected
+request, while concurrent requests continue to be served with the still-valid cached credentials. Notes:
 
 - The STS endpoint is chosen the same way as for EKS web identity: `STS_ENDPOINT` when set, otherwise
   `https://sts.<AWS_REGION>.amazonaws.com` when `AWS_STS_REGIONAL_ENDPOINTS=regional`, otherwise the global
@@ -682,7 +683,20 @@ keys regularly expire, so services using them must refresh frequently.
 
 The gateway caches these temporary credentials in memory only: OSS uses an njs
 shared dictionary and NGINX Plus uses keyval. Current versions do not write
-temporary AWS credentials to disk. On startup the container removes any legacy
+temporary AWS credentials to disk.
+
+Credential refreshes are single-flighted: when the cached credentials enter the
+4.5-minute pre-expiry refresh margin, one request wins an atomic sentinel in a
+dedicated shared-memory zone (`credential_refresh_lock`, declared in its own
+`conf.d` file shared by both flavors) and fetches new credentials, while every
+other request keeps using the cached, still-valid set. If the elected refresh
+fails, the cached credentials continue to be served and the refresh re-arms
+every 30 seconds until they actually expire. Requests block on the fetch only
+when no still-valid cached credentials exist: a cold start, or credentials
+already past their actual expiry (for example, after a provider outage that
+outlasts the refresh margin).
+
+On startup the container removes any legacy
 credential cache left behind by an older OSS image, checking every path the old
 code could have written: `AWS_CREDENTIALS_TEMP_FILE`, `${TMPDIR}/credentials.json`,
 and `/tmp/credentials.json`. If you dropped a custom `TMPDIR` or
@@ -714,7 +728,9 @@ with a 403/404/405 status, the gateway automatically retries without a session
 token (IMDSv1), matching AWS SDK behavior. This lets the gateway work on
 instances where the hop limit was not raised, but only when the instance still
 allows IMDSv1 (`HttpTokens=optional`); each credential refresh then waits for
-the token request to time out first. Instances enforcing IMDSv2
+the token request to time out first — but only in the single request performing
+that refresh; concurrent requests keep being served with the cached credentials
+until they actually expire. Instances enforcing IMDSv2
 (`HttpTokens=required`) still require the hop limit change above.
 
 To disable the IMDSv1 fallback entirely so that credential retrieval fails

--- a/oss/etc/nginx/conf.d/instance_credential_cache.conf
+++ b/oss/etc/nginx/conf.d/instance_credential_cache.conf
@@ -7,5 +7,8 @@
 # built. Credential freshness is enforced by the expiration field that
 # fetchCredentials() checks on every request, so time-based eviction adds
 # nothing but that race. The zone holds one small JSON entry; 64k leaves
-# ample slab headroom for large federated STS session tokens.
+# ample slab headroom for large federated STS session tokens. The refresh
+# itself is single-flighted via the credential_refresh_lock zone declared
+# once for both flavors in
+# common/etc/nginx/conf.d/credential_refresh_lock.conf (GH-591).
 js_shared_dict_zone zone=instance_credential_cache:64k;

--- a/plus/etc/nginx/conf.d/instance_credential_cache.conf
+++ b/plus/etc/nginx/conf.d/instance_credential_cache.conf
@@ -2,3 +2,7 @@
 # dynamic credential providers such as IMDS, ECS, IRSA, and EKS Pod Identity.
 keyval_zone zone=instance_credential_cache:32k type=string timeout=6h;
 keyval 'instance_credential' $instance_credential_json zone=instance_credential_cache;
+
+# The credential refresh is single-flighted via the credential_refresh_lock
+# zone declared once for both flavors in
+# common/etc/nginx/conf.d/credential_refresh_lock.conf (GH-591).

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -899,6 +899,7 @@ download "common/etc/nginx/templates/gateway/s3_location_common.conf.template" "
 download "oss/etc/nginx/templates/upstreams.conf.template" "/etc/nginx/templates/upstreams.conf.template"
 download "oss/etc/nginx/templates/gateway/server_variables.conf.template" "/etc/nginx/templates/gateway/server_variables.conf.template"
 download "oss/etc/nginx/conf.d/instance_credential_cache.conf" "/etc/nginx/conf.d/instance_credential_cache.conf"
+download "common/etc/nginx/conf.d/credential_refresh_lock.conf" "/etc/nginx/conf.d/credential_refresh_lock.conf"
 
 # Older standalone installs cached temporary AWS credentials on disk,
 # resolving the path exactly as the deleted _credentialsTempFile() did: an

--- a/test/unit/awscredentials_test.js
+++ b/test/unit/awscredentials_test.js
@@ -82,6 +82,16 @@ const ECS_CREDS_URL = `http://169.254.170.2${ECS_CREDS_RELATIVE_URI}`;
  */
 const INSTANCE_CREDENTIAL_CACHE_KEY = credentialCacheMock.INSTANCE_CREDENTIAL_CACHE_KEY;
 
+/**
+ * Key used by awscredentials.js for the single-flight refresh sentinel (GH-591).
+ */
+const CREDENTIAL_REFRESH_LOCK_KEY = credentialCacheMock.CREDENTIAL_REFRESH_LOCK_KEY;
+
+/**
+ * Value awscredentials.js stores under the sentinel key (GH-591).
+ */
+const CREDENTIAL_REFRESH_LOCK_VALUE = credentialCacheMock.CREDENTIAL_REFRESH_LOCK_VALUE;
+
 const resetSharedCredentialCache = credentialCacheMock.resetSharedCredentialCache;
 
 /**
@@ -161,6 +171,73 @@ function makeRecordingRequest(state) {
             state.returnedCode = code;
         },
     };
+}
+
+/**
+ * Builds the distinctive cached-credential object carrying the given
+ * expiration, so assertions can prove whether the cached or a freshly
+ * fetched set won. Single source of truth for the A_CACHED_* sentinel
+ * values across the shared-dict and keyval seeding paths.
+ */
+function makeCachedCredentials(expiration) {
+    return {
+        accessKeyId: 'A_CACHED_ACCESS_KEY_ID',
+        secretAccessKey: 'A_CACHED_SECRET_ACCESS_KEY',
+        sessionToken: 'A_CACHED_SECURITY_TOKEN',
+        expiration: expiration,
+    };
+}
+
+/**
+ * Seeds the OSS shared-dict credential cache with the distinctive
+ * credentials from makeCachedCredentials.
+ */
+function seedCachedCredentials(expiration) {
+    globalThis.ngx.shared.instance_credential_cache.set(INSTANCE_CREDENTIAL_CACHE_KEY,
+        JSON.stringify(makeCachedCredentials(expiration)));
+}
+
+/**
+ * Installs an ngx.fetch stub that resolves every request with the given
+ * response object and records the last fetched URL as state.fetchedUrl
+ * (null when no fetch happened). Recording instead of throwing keeps stub
+ * failures from being swallowed by fetchCredentials' try/catch.
+ */
+function installFetchStub(state, response) {
+    state.fetchedUrl = null;
+    globalThis.ngx.fetch = function (url) {
+        state.fetchedUrl = url;
+
+        return Promise.resolve(response);
+    };
+}
+
+/**
+ * Installs a recording ngx.fetch stub that resolves with the standard mock
+ * ECS credentials payload.
+ */
+function installRecordingFetch(state) {
+    installFetchStub(state, {
+        ok: true,
+        json: function () {
+            return Promise.resolve(MOCK_AWS_CREDS_RESPONSE);
+        }
+    });
+}
+
+/**
+ * Installs a recording ngx.fetch stub that fails every request with a 503.
+ */
+function installFailingFetch(state) {
+    installFetchStub(state, {
+        ok: false,
+        status: 503,
+        json: function () {
+            return Promise.resolve({
+                message: 'Service Unavailable',
+            });
+        }
+    });
 }
 
 
@@ -508,6 +585,296 @@ async function testFetchCredentialsUsesFreshCache() {
         }
     } finally {
         delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsInMarginElectsSingleRefresher() {
+    printHeader('testFetchCredentialsInMarginElectsSingleRefresher');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* 60s ahead: inside the 4.5-minute refresh margin but still valid. */
+    seedCachedCredentials(new Date(Date.now() + 60000).toISOString());
+    const state = {};
+    installRecordingFetch(state);
+    const r = makeExpect200Request();
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (state.fetchedUrl !== ECS_CREDS_URL) {
+            throw 'In-margin request with a free lock must refresh. ' +
+                `Recorded refresh URL: ${state.fetchedUrl}`;
+        }
+        const lock = globalThis.ngx.shared.credential_refresh_lock.get(CREDENTIAL_REFRESH_LOCK_KEY);
+        if (lock !== CREDENTIAL_REFRESH_LOCK_VALUE) {
+            throw 'The elected refresher must hold the refresh lock. ' +
+                `Lock value: ${lock}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsInMarginServesCachedWhenLockHeld() {
+    printHeader('testFetchCredentialsInMarginServesCachedWhenLockHeld');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    seedCachedCredentials(new Date(Date.now() + 60000).toISOString());
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const fetchState = {};
+    installRecordingFetch(fetchState);
+    const state = {};
+    const r = makeRecordingRequest(state);
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (fetchState.fetchedUrl !== null) {
+            throw 'A request that lost the lock election must not refresh. ' +
+                `Attempted fetch URL: ${fetchState.fetchedUrl}`;
+        }
+        if (state.returnedCode !== 200) {
+            throw 'Expected 200 status code, got: ' + state.returnedCode;
+        }
+        const cached = JSON.parse(globalThis.ngx.shared.instance_credential_cache.get(INSTANCE_CREDENTIAL_CACHE_KEY));
+        if (cached.accessKeyId !== 'A_CACHED_ACCESS_KEY_ID') {
+            throw 'The cached credentials must not be overwritten. ' +
+                `Cached access key: ${cached.accessKeyId}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsExpiredCacheBypassesLock() {
+    printHeader('testFetchCredentialsExpiredCacheBypassesLock');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* Truly expired: nothing valid is left to serve, so a held sentinel
+       (e.g. from a hung refresher) must not gate the refresh. */
+    seedCachedCredentials(new Date(Date.now() - 60000).toISOString());
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const state = {};
+    installRecordingFetch(state);
+    const r = makeExpect200Request();
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (state.fetchedUrl !== ECS_CREDS_URL) {
+            throw 'Truly expired credentials must refresh even with the lock held. ' +
+                `Recorded refresh URL: ${state.fetchedUrl}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsColdStartIgnoresLock() {
+    printHeader('testFetchCredentialsColdStartIgnoresLock');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* No cached credentials at all: cold start keeps blocking-fetch-for-all. */
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const state = {};
+    installRecordingFetch(state);
+    const r = makeExpect200Request();
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (state.fetchedUrl !== ECS_CREDS_URL) {
+            throw 'A cold start must fetch even with the lock held. ' +
+                `Recorded refresh URL: ${state.fetchedUrl}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsNumericEpochExpirationInMargin() {
+    printHeader('testFetchCredentialsNumericEpochExpirationInMargin');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* Numeric expirations are epoch SECONDS; pins the x1000 conversion
+       feeding the margin logic - a regression comparing seconds as
+       milliseconds would look ancient and herd. */
+    seedCachedCredentials(Math.floor((Date.now() + 60000) / 1000));
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const fetchState = {};
+    installRecordingFetch(fetchState);
+    const state = {};
+    const r = makeRecordingRequest(state);
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (fetchState.fetchedUrl !== null) {
+            throw 'An in-margin numeric expiration must serve from cache when the lock is held. ' +
+                `Attempted fetch URL: ${fetchState.fetchedUrl}`;
+        }
+        if (state.returnedCode !== 200) {
+            throw 'Expected 200 status code, got: ' + state.returnedCode;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsNaNExpirationRefetches() {
+    printHeader('testFetchCredentialsNaNExpirationRefetches');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* An unparseable expiration means the cached credentials cannot be
+       trusted to be valid, so the election must be skipped. */
+    seedCachedCredentials('not-a-date');
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const state = {};
+    installRecordingFetch(state);
+    const r = makeExpect200Request();
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (state.fetchedUrl !== ECS_CREDS_URL) {
+            throw 'An unparseable expiration must refresh even with the lock held. ' +
+                `Recorded refresh URL: ${state.fetchedUrl}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsInMarginHolderFailureServesCached() {
+    printHeader('testFetchCredentialsInMarginHolderFailureServesCached');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    seedCachedCredentials(new Date(Date.now() + 60000).toISOString());
+    const fetchState = {};
+    installFailingFetch(fetchState);
+    const state = {};
+    const r = makeRecordingRequest(state);
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (fetchState.fetchedUrl !== ECS_CREDS_URL) {
+            throw 'The elected refresher must have attempted the refresh. ' +
+                `Recorded refresh URL: ${fetchState.fetchedUrl}`;
+        }
+        if (state.returnedCode !== 200) {
+            throw 'A failed refresh with still-valid cached credentials must ' +
+                'serve from cache, got: ' + state.returnedCode;
+        }
+        const cached = JSON.parse(globalThis.ngx.shared.instance_credential_cache.get(INSTANCE_CREDENTIAL_CACHE_KEY));
+        if (cached.accessKeyId !== 'A_CACHED_ACCESS_KEY_ID') {
+            throw 'A failed refresh must not overwrite the cached credentials. ' +
+                `Cached access key: ${cached.accessKeyId}`;
+        }
+        const lock = globalThis.ngx.shared.credential_refresh_lock.get(CREDENTIAL_REFRESH_LOCK_KEY);
+        if (lock !== CREDENTIAL_REFRESH_LOCK_VALUE) {
+            throw 'The lock must stay held after a failed refresh so its ' +
+                `timeout paces the retries. Lock value: ${lock}`;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsColdStartFailureStill500s() {
+    printHeader('testFetchCredentialsColdStartFailureStill500s');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    const fetchState = {};
+    installFailingFetch(fetchState);
+    const state = {};
+    const r = makeRecordingRequest(state);
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (state.returnedCode !== 500) {
+            throw 'A cold-start fetch failure must surface as a 500, got: ' +
+                state.returnedCode;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+async function testFetchCredentialsInMarginKeyValStoreUsesLock() {
+    printHeader('testFetchCredentialsInMarginKeyValStoreUsesLock');
+    clearProviderEnv();
+    process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'] = ECS_CREDS_RELATIVE_URI;
+    /* Plus path: credentials come from the keyval store via r.variables, but
+       the sentinel still lives in the njs shared dict - the election must be
+       backend-independent. */
+    globalThis.ngx.shared.credential_refresh_lock.set(CREDENTIAL_REFRESH_LOCK_KEY, CREDENTIAL_REFRESH_LOCK_VALUE);
+    const fetchState = {};
+    installRecordingFetch(fetchState);
+    const state = {};
+    const r = makeRecordingRequest(state);
+    r.variables = {
+        cache_instance_credentials_enabled: 1,
+        instance_credential_json: JSON.stringify(
+            makeCachedCredentials(new Date(Date.now() + 60000).toISOString()))
+    };
+
+    try {
+        await awscred.fetchCredentials(r);
+
+        if (fetchState.fetchedUrl !== null) {
+            throw 'An in-margin keyval request that lost the election must not refresh. ' +
+                `Attempted fetch URL: ${fetchState.fetchedUrl}`;
+        }
+        if (state.returnedCode !== 200) {
+            throw 'Expected 200 status code, got: ' + state.returnedCode;
+        }
+    } finally {
+        delete process.env['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'];
+    }
+}
+
+function testTryAcquireCredentialRefreshLock() {
+    printHeader('testTryAcquireCredentialRefreshLock');
+    const r = {
+        log: function(msg) {
+            console.log(msg);
+        },
+    };
+
+    try {
+        resetSharedCredentialCache();
+        if (awscred._tryAcquireCredentialRefreshLock(r) !== true) {
+            throw 'The first acquisition on a free lock must succeed';
+        }
+        if (awscred._tryAcquireCredentialRefreshLock(r) !== false) {
+            throw 'A second acquisition on a held lock must fail';
+        }
+
+        /* Fail-open when the lock zone is missing (e.g. a custom NGINX
+           configuration that predates GH-591): refresh must proceed. */
+        globalThis.ngx.shared = {
+            instance_credential_cache: credentialCacheMock.makeSharedCredentialCache()
+        };
+        if (awscred._tryAcquireCredentialRefreshLock(r) !== true) {
+            throw 'A missing lock zone must fail open and allow the refresh';
+        }
+
+        /* Fail-open when add() throws (e.g. SharedMemoryError on a full
+           zone): refresh must proceed. */
+        globalThis.ngx.shared = {
+            credential_refresh_lock: {
+                add: function() {
+                    throw 'SharedMemoryError: no free space';
+                }
+            }
+        };
+        if (awscred._tryAcquireCredentialRefreshLock(r) !== true) {
+            throw 'A throwing add() must fail open and allow the refresh';
+        }
+    } finally {
+        resetSharedCredentialCache();
     }
 }
 
@@ -1603,6 +1970,16 @@ async function test() {
     await testEcsCredentialRetrieval();
     await testFetchCredentialsRefreshesExpiredCache();
     await testFetchCredentialsUsesFreshCache();
+    await testFetchCredentialsInMarginElectsSingleRefresher();
+    await testFetchCredentialsInMarginServesCachedWhenLockHeld();
+    await testFetchCredentialsExpiredCacheBypassesLock();
+    await testFetchCredentialsColdStartIgnoresLock();
+    await testFetchCredentialsNumericEpochExpirationInMargin();
+    await testFetchCredentialsNaNExpirationRefetches();
+    await testFetchCredentialsInMarginHolderFailureServesCached();
+    await testFetchCredentialsColdStartFailureStill500s();
+    await testFetchCredentialsInMarginKeyValStoreUsesLock();
+    testTryAcquireCredentialRefreshLock();
     await testEKSPodIdentityCredentialRetrieval();
     await testEKSPodIdentityCredentialRetrievalNon200Response();
     await testEc2CredentialRetrievalNon200Response();

--- a/test/unit/credential_cache_mock.js
+++ b/test/unit/credential_cache_mock.js
@@ -15,12 +15,13 @@
  */
 
 /**
- * Shared unit-test mock of the `instance_credential_cache` njs shared
- * dictionary that oss/etc/nginx/conf.d/instance_credential_cache.conf
- * configures in production. The njs CLI provides no `ngx.shared`, so the
- * suites that exercise credential caching install this mock on
- * `globalThis.ngx` first. Kept in one module so the suites cannot drift in
- * how they emulate the NgxSharedDict get/set contract.
+ * Shared unit-test mock of the `instance_credential_cache` and
+ * `credential_refresh_lock` njs shared dictionaries that
+ * oss/etc/nginx/conf.d/instance_credential_cache.conf configures in
+ * production. The njs CLI provides no `ngx.shared`, so the suites that
+ * exercise credential caching install this mock on `globalThis.ngx` first.
+ * Kept in one module so the suites cannot drift in how they emulate the
+ * NgxSharedDict get/set/add contract.
  *
  * @module credential_cache_mock
  * @alias CredentialCacheMock
@@ -37,11 +38,28 @@ import awscred from "include/awscredentials.js";
 const INSTANCE_CREDENTIAL_CACHE_KEY = awscred.INSTANCE_CREDENTIAL_CACHE_KEY;
 
 /**
+ * Key used by awscredentials.js for the single-flight refresh sentinel
+ * (GH-591), re-exported from the production module for the same
+ * anti-drift reason as INSTANCE_CREDENTIAL_CACHE_KEY above.
+ * @type {string}
+ */
+const CREDENTIAL_REFRESH_LOCK_KEY = awscred.CREDENTIAL_REFRESH_LOCK_KEY;
+
+/**
+ * Value the production module stores under the sentinel key, re-exported
+ * for the same anti-drift reason.
+ * @type {string}
+ */
+const CREDENTIAL_REFRESH_LOCK_VALUE = awscred.CREDENTIAL_REFRESH_LOCK_VALUE;
+
+/**
  * Builds a minimal NgxSharedDict-alike backed by a plain object: get()
- * returns undefined on a miss and set() is chainable, matching the real
- * shared-dictionary API that awscredentials.js relies on.
+ * returns undefined on a miss, set() is chainable, and add() refuses an
+ * existing key, matching the real shared-dictionary API that
+ * awscredentials.js relies on. No TTL emulation: production never passes a
+ * per-item timeout, so tests manipulate entry lifetime via set()/clear().
  *
- * @returns {object} shared-dictionary mock with get/set/clear
+ * @returns {object} shared-dictionary mock with get/set/add/clear
  */
 function makeSharedCredentialCache() {
     let values = {};
@@ -54,6 +72,13 @@ function makeSharedCredentialCache() {
             values[key] = value;
             return this;
         },
+        add: function(key, value) {
+            if (key in values) {
+                return false;
+            }
+            values[key] = value;
+            return true;
+        },
         clear: function() {
             values = {};
         }
@@ -61,16 +86,20 @@ function makeSharedCredentialCache() {
 }
 
 /**
- * Installs a fresh, empty credential cache mock on globalThis.ngx.shared so
- * that each test case starts without cached credentials from earlier cases.
+ * Installs fresh, empty credential cache and refresh-lock mocks on
+ * globalThis.ngx.shared so that each test case starts without cached
+ * credentials or a held sentinel from earlier cases.
  */
 function resetSharedCredentialCache() {
     globalThis.ngx.shared = {
-        instance_credential_cache: makeSharedCredentialCache()
+        instance_credential_cache: makeSharedCredentialCache(),
+        credential_refresh_lock: makeSharedCredentialCache()
     };
 }
 
 export default {
+    CREDENTIAL_REFRESH_LOCK_KEY,
+    CREDENTIAL_REFRESH_LOCK_VALUE,
     INSTANCE_CREDENTIAL_CACHE_KEY,
     makeSharedCredentialCache,
     resetSharedCredentialCache


### PR DESCRIPTION
### Proposed changes

Fixes #591.

`fetchCredentials` runs per request via `auth_request /aws/credentials/retrieve`. When the cached credentials
crossed the 4.5-minute expiry margin, every in-flight request independently walked the provider ladder: N
concurrent requests produced N provider calls and N−1 redundant cache overwrites. Since #590 (GH-122) added the
STS AssumeRole path, that herd hits a remote, rate-limited API, pays a full SigV4 signing round per call, and
mints one CloudTrail role session per request — recurring roughly every 55 minutes under sustained load.

**How it works now:**

- Inside the refresh margin the cached credentials are still fully valid, so exactly one request per window is
  elected to refresh via an atomic shared-dict `add()` on a new `credential_refresh_lock` zone; every other
  request answers from the cache. Cold starts, truly expired credentials, and unparseable expirations still
  fetch unconditionally (nothing valid is left to serve), and the election covers the whole provider ladder.
- The zone is declared once for both flavors in `common/etc/nginx/conf.d/credential_refresh_lock.conf` (both
  Dockerfiles `COPY common/etc`; the standalone installer gained a matching `download` line). It is deliberately
  separate from `instance_credential_cache`: the sentinel needs `timeout=30s` so a crashed, hung, or failed
  refresher self-releases, while the credential entry must never be evicted by a zone timeout — and njs throws
  if a per-item timeout is passed to a zone declared without one. Plus keeps its keyval credential cache but
  uses the njs shared dict for the sentinel, since keyval has no atomic add.
- Lock acquisition fails **open** (refresh proceeds — the pre-fix herd) when the zone is missing or `add()`
  throws, so custom configurations degrade instead of turning a missing declaration into an outage at expiry.
- An elected refresher whose fetch fails now serves the still-valid cached credentials with a 200; the validity
  deadline is re-checked at failure time, so a fetch that outlasts the remaining validity still surfaces the
  500. Cold-start failures still 500. Instance-provider fetch failures now log at error level instead of only
  under DEBUG, so absorbed refresh failures remain operator-visible.

**Testing:** ten new unit tests cover the election, lock-held serving on both the shared-dict and keyval
backends, expired/cold-start/NaN/numeric-epoch bypasses, the holder-failure fallback (and that cold-start
failures still 500), and the fail-open helper directly. The shared credential-cache mock gained `add()` and the
second zone. Full `make test` passes for OSS and the unit + integration suites pass against the Plus image; no
integration-test changes were needed (the ECS mock's 2100 expiration keeps CI out of the margin, so no timing
flakiness is introduced). No new environment variables.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).