### PR TITLE
fix: reject trailing-newline boolean spellings like njs does (#600)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ and the AWS CLI).
 - `make test-unit` / `make test-integration` — run just one half of the suite
   against the already-built image.
 - `make test-matrix` — reproduce the CI matrix locally.
-- `make lint` — checkmake + shellcheck + rumdl (Markdown).
+- `make lint` — checkmake + shellcheck + rumdl (Markdown) + the
+  `gateway_env_lib.sh` sync check and its self-test.
 - `make lint-md` / `make fmt-md` — report or auto-fix Markdown issues with
   `rumdl` (config in `.rumdl.toml`) without running the other linters.
 - `make docs` — generate JSDoc reference documentation.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -271,10 +271,21 @@ lint: makefile-check shellcheck envlib-sync-check lint-md ## Run all linters (ch
 makefile-check: ## Lint this Makefile with checkmake
 	cd "$(BASE_DIR)" && checkmake --config .checkmake.ini GNUmakefile
 
+# The empty-region guards keep the check from passing vacuously: if the BEGIN
+# marker ever disappears from a file, its sed extraction is empty, and two
+# empty extractions would otherwise diff clean.
 envlib-sync-check: ## Verify the installer's synced copy of gateway_env_lib.sh matches the canonical file
-	@cd "$(BASE_DIR)" && diff \
-		<(sed -n '/^# --- gateway_env_lib functions BEGIN ---$$/,/^# --- gateway_env_lib functions END ---$$/p' common/etc/nginx/gateway_env_lib.sh) \
-		<(sed -n '/^# --- gateway_env_lib functions BEGIN ---$$/,/^# --- gateway_env_lib functions END ---$$/p' standalone_ubuntu_oss_install.sh) \
+	@cd "$(BASE_DIR)"; \
+	extract() { sed -n '/^# --- gateway_env_lib functions BEGIN ---$$/,/^# --- gateway_env_lib functions END ---$$/p' "$$1"; }; \
+	lib_region="$$(extract common/etc/nginx/gateway_env_lib.sh)"; \
+	installer_region="$$(extract standalone_ubuntu_oss_install.sh)"; \
+	if [ -z "$$lib_region" ]; then \
+		echo "envlib-sync-check: marked 'gateway_env_lib functions' region not found in common/etc/nginx/gateway_env_lib.sh"; exit 1; \
+	fi; \
+	if [ -z "$$installer_region" ]; then \
+		echo "envlib-sync-check: marked 'gateway_env_lib functions' region not found in standalone_ubuntu_oss_install.sh"; exit 1; \
+	fi; \
+	diff <(printf '%s\n' "$$lib_region") <(printf '%s\n' "$$installer_region") \
 		|| { echo "gateway_env_lib functions differ between common/etc/nginx/gateway_env_lib.sh and standalone_ubuntu_oss_install.sh - edit the marked regions together"; exit 1; }
 
 shellcheck: ## Lint shell scripts (pre-existing findings excluded, see SHELLCHECK_EXCLUDES)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -72,7 +72,7 @@ SHELL_SCRIPTS     := test.sh \
 SHELLCHECK_EXCLUDES := SC2027,SC2034,SC2068,SC2140
 
 # Single line on purpose: checkmake's parser does not follow continuations
-.PHONY: help check-tools check-nginx-type check-s3-style check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck envlib-sync-check lint-md fmt-md hadolint docs docs-open jsdoc clean clean-images all ci
+.PHONY: help check-tools check-nginx-type check-s3-style check-plus-creds build build-oss build-plus build-latest-njs build-unprivileged test test-unit test-integration test-latest-njs test-unprivileged test-matrix test-matrix-plus retest retest-latest-njs retest-unprivileged lint makefile-check shellcheck envlib-sync-check envlib-sync-selftest lint-md fmt-md hadolint docs docs-open jsdoc clean clean-images all ci
 
 ##@ Help
 
@@ -265,7 +265,7 @@ retest-unprivileged: check-nginx-type check-s3-style check-tools ## Test the cur
 
 ##@ Lint
 
-lint: makefile-check shellcheck envlib-sync-check lint-md ## Run all linters (checkmake + shellcheck + rumdl + helper sync)
+lint: makefile-check shellcheck envlib-sync-check envlib-sync-selftest lint-md ## Run all linters (checkmake + shellcheck + rumdl + helper sync)
 	@echo "All lints passed"
 
 makefile-check: ## Lint this Makefile with checkmake
@@ -287,6 +287,9 @@ envlib-sync-check: ## Verify the installer's synced copy of gateway_env_lib.sh m
 	fi; \
 	diff <(printf '%s\n' "$$lib_region") <(printf '%s\n' "$$installer_region") \
 		|| { echo "gateway_env_lib functions differ between common/etc/nginx/gateway_env_lib.sh and standalone_ubuntu_oss_install.sh - edit the marked regions together"; exit 1; }
+
+envlib-sync-selftest: ## Verify envlib-sync-check itself catches drift and missing markers
+	@bash "$(BASE_DIR)test/envlib_sync_check_test.sh"
 
 shellcheck: ## Lint shell scripts (pre-existing findings excluded, see SHELLCHECK_EXCLUDES)
 	cd "$(BASE_DIR)" && shellcheck --severity=warning \

--- a/common/etc/nginx/gateway_env_lib.sh
+++ b/common/etc/nginx/gateway_env_lib.sh
@@ -41,16 +41,24 @@
 # the empty string).
 
 # --- gateway_env_lib functions BEGIN ---
-# Prints $1 lowercased (boolean spellings are ASCII, so tr's classes suffice).
-lowercaseValue() {
-  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+# Sets gw_lowercased to $1 lowercased (boolean spellings are ASCII, so tr's
+# classes suffice). The result travels through a variable, not stdout: a
+# command substitution around the value would strip trailing newlines, making
+# the shell accept spellings like 'true<newline>' that utils.js#parseBoolean
+# rejects. The 'x' sentinel carries the trailing newlines through the one
+# substitution used internally.
+gw_lowercased=""
+lowercaseValueInto() {
+  gw_lowercased="$(printf '%sx' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  gw_lowercased="${gw_lowercased%x}"
 }
 
 # Prints 1 when $1 is a recognized true spelling, otherwise 0. Unrecognized
 # spellings mean false here so that startup validation, not parsing, is the
 # single place that rejects them.
 parseBoolean() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1)
       echo 1
       ;;
@@ -68,7 +76,8 @@ parseBoolean() {
 # rejected it already, and the historical behavior of both tri-state
 # consumers was to fall back to the unset case.
 parseBooleanTristate() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1)
       echo 1
       ;;
@@ -83,7 +92,8 @@ parseBooleanTristate() {
 
 # Succeeds (exit 0) when $1 is a recognized boolean spelling.
 isBooleanSpelling() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1 | false | no | 0)
       return 0
       ;;

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -35,16 +35,24 @@ fi
 # unpinned, unverified file as root. `make lint` (envlib-sync-check) fails
 # when the two regions differ - edit them together.
 # --- gateway_env_lib functions BEGIN ---
-# Prints $1 lowercased (boolean spellings are ASCII, so tr's classes suffice).
-lowercaseValue() {
-  printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]'
+# Sets gw_lowercased to $1 lowercased (boolean spellings are ASCII, so tr's
+# classes suffice). The result travels through a variable, not stdout: a
+# command substitution around the value would strip trailing newlines, making
+# the shell accept spellings like 'true<newline>' that utils.js#parseBoolean
+# rejects. The 'x' sentinel carries the trailing newlines through the one
+# substitution used internally.
+gw_lowercased=""
+lowercaseValueInto() {
+  gw_lowercased="$(printf '%sx' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  gw_lowercased="${gw_lowercased%x}"
 }
 
 # Prints 1 when $1 is a recognized true spelling, otherwise 0. Unrecognized
 # spellings mean false here so that startup validation, not parsing, is the
 # single place that rejects them.
 parseBoolean() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1)
       echo 1
       ;;
@@ -62,7 +70,8 @@ parseBoolean() {
 # rejected it already, and the historical behavior of both tri-state
 # consumers was to fall back to the unset case.
 parseBooleanTristate() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1)
       echo 1
       ;;
@@ -77,7 +86,8 @@ parseBooleanTristate() {
 
 # Succeeds (exit 0) when $1 is a recognized boolean spelling.
 isBooleanSpelling() {
-  case "$(lowercaseValue "${1:-}")" in
+  lowercaseValueInto "${1:-}"
+  case "${gw_lowercased}" in
     true | yes | 1 | false | no | 0)
       return 0
       ;;

--- a/test/envlib_sync_check_test.sh
+++ b/test/envlib_sync_check_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+#
+#  Copyright 2026 F5, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+# Self-test for the envlib-sync-check lint target (GH-600): the guard that
+# keeps the installer's synced copy of gateway_env_lib.sh from drifting is
+# itself only useful if its failure branches actually fire. Each case copies
+# the real GNUmakefile and the two synced files into a scratch directory,
+# mutates them, and runs the real target there via make -C, so the sed
+# extraction and the guards are exercised exactly as `make lint` runs them.
+#
+# Needs only GNU make and coreutils - no docker, no image.
+
+set -o errexit   # abort on nonzero exit status
+set -o pipefail  # don't hide errors within pipes
+set -o nounset   # abort on unbound variable
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+test_fail_exit_code=2
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "${sandbox}"' EXIT
+
+failCase() {
+  >&2 printf '%s\n' "$@"
+  exit "${test_fail_exit_code}"
+}
+
+# resetSandbox recreates pristine copies of the three files the target reads.
+resetSandbox() {
+  mkdir -p "${sandbox}/common/etc/nginx"
+  cp "${repo_dir}/GNUmakefile" "${sandbox}/GNUmakefile"
+  cp "${repo_dir}/common/etc/nginx/gateway_env_lib.sh" \
+    "${sandbox}/common/etc/nginx/gateway_env_lib.sh"
+  cp "${repo_dir}/standalone_ubuntu_oss_install.sh" \
+    "${sandbox}/standalone_ubuntu_oss_install.sh"
+}
+
+# runCheck prints the target's combined output; its exit status is the
+# target's. The caller captures both.
+runCheck() {
+  make -s -C "${sandbox}" envlib-sync-check 2>&1
+}
+
+# assertCheckFails <case description> <expected output fragment> runs the
+# target in the current sandbox state and requires a nonzero exit whose
+# output contains the fragment.
+assertCheckFails() {
+  description=$1
+  expected_fragment=$2
+
+  echo "  case: ${description}"
+  if output="$(runCheck)"; then
+    failCase "FAIL: envlib-sync-check passed but must fail when ${description}" \
+      "output:" "${output}"
+  fi
+  if ! printf '%s' "${output}" | grep -qF "${expected_fragment}"; then
+    failCase "FAIL: envlib-sync-check failed as expected (${description}) but without the expected diagnostic" \
+      "expected fragment: ${expected_fragment}" "output:" "${output}"
+  fi
+}
+
+# Pristine copies must pass: this validates the fixture itself, so the
+# failure cases below cannot pass vacuously against a broken sandbox.
+echo "  case: pristine copies stay in sync"
+resetSandbox
+if ! output="$(runCheck)"; then
+  failCase "FAIL: envlib-sync-check must pass on pristine copies" \
+    "output:" "${output}"
+fi
+
+# A drifted function body in one copy must be caught.
+resetSandbox
+sed -i 's/true | yes | 1)/true | yes | 1 | maybe)/' \
+  "${sandbox}/standalone_ubuntu_oss_install.sh"
+assertCheckFails "the installer copy drifts" \
+  "gateway_env_lib functions differ"
+
+# Markers stripped from BOTH files must be caught: two empty sed extractions
+# would otherwise diff clean (the vacuous-pass guard).
+resetSandbox
+sed -i '/gateway_env_lib functions BEGIN/d' \
+  "${sandbox}/common/etc/nginx/gateway_env_lib.sh" \
+  "${sandbox}/standalone_ubuntu_oss_install.sh"
+assertCheckFails "the markers are stripped from both files" \
+  "region not found"
+
+# A marker stripped from a single file must be caught and the diagnostic must
+# name that file.
+resetSandbox
+sed -i '/gateway_env_lib functions BEGIN/d' \
+  "${sandbox}/common/etc/nginx/gateway_env_lib.sh"
+assertCheckFails "the marker is stripped from the library file" \
+  "region not found in common/etc/nginx/gateway_env_lib.sh"
+
+echo "PASS: envlib-sync-check catches drift and missing markers"

--- a/test/integration/test_entrypoint_boolean_validation.sh
+++ b/test/integration/test_entrypoint_boolean_validation.sh
@@ -140,6 +140,11 @@ printf '%s\n' true TRUE TrUe yes YES yEs Yes 1 false FALSE FaLsE no NO nO No 0 \
 while IFS= read -r v; do
   printf '%s=%s\n' "$v" "$(parseBoolean "$v")"
 done < /tmp/spellings > /tmp/shell_verdicts
+# A trailing newline cannot ride through the line-based spellings file, and it
+# is the one artifact command substitution would hide (GH-600 review): probe
+# it explicitly on both sides.
+nl="$(printf '\nx')"; nl="${nl%x}"
+printf 'trailing-newline=%s\n' "$(parseBoolean "true${nl}")" >> /tmp/shell_verdicts
 cat > /tmp/pb_test.js << 'JS'
 import utils from "include/utils.js";
 import fs from "fs";
@@ -148,6 +153,7 @@ lines.pop();
 lines.forEach(function (v) {
     console.log(v + "=" + (utils.parseBoolean(v) ? "1" : "0"));
 });
+console.log("trailing-newline=" + (utils.parseBoolean("true\n") ? "1" : "0"));
 JS
 if /usr/bin/njs -t module /dev/null > /dev/null 2>&1; then
   njs_flags="-t module"

--- a/test/integration/test_entrypoint_boolean_validation.sh
+++ b/test/integration/test_entrypoint_boolean_validation.sh
@@ -142,9 +142,19 @@ while IFS= read -r v; do
 done < /tmp/spellings > /tmp/shell_verdicts
 # A trailing newline cannot ride through the line-based spellings file, and it
 # is the one artifact command substitution would hide (GH-600 review): probe
-# it explicitly on both sides.
+# it explicitly on both sides, and pin the other two helpers to the same
+# strictness (they share lowercaseValueInto, so a regression means someone
+# stopped routing through it).
 nl="$(printf '\nx')"; nl="${nl%x}"
 printf 'trailing-newline=%s\n' "$(parseBoolean "true${nl}")" >> /tmp/shell_verdicts
+if [ "$(parseBooleanTristate "false${nl}")" != "" ]; then
+  echo "parseBooleanTristate accepted a trailing-newline spelling"
+  exit 1
+fi
+if isBooleanSpelling "true${nl}"; then
+  echo "isBooleanSpelling accepted a trailing-newline spelling"
+  exit 1
+fi
 cat > /tmp/pb_test.js << 'JS'
 import utils from "include/utils.js";
 import fs from "fs";

--- a/test/unit/utils_test.js
+++ b/test/unit/utils_test.js
@@ -68,7 +68,7 @@ function testParseBoolean() {
         // vars read at module scope; the near-misses cover whitespace and
         // the on/off family that is deliberately not in the grammar.
         const values = ['on', 'off', 'enabled', 'disabled', '01',
-            'yes ', ' true', 'truthy', '', undefined, null];
+            'yes ', ' true', 'true\n', 'truthy', '', undefined, null];
         values.forEach((value) => {
             if (utils.parseBoolean(value) !== false) {
                 throw `Unrecognized value not parsed as false: [${value}]`;


### PR DESCRIPTION
### Proposed changes

Follow-up to #601 (GH-600), addressing two findings from post-merge code review of that change.

**1. Trailing-newline divergence between the shell and njs boolean parsers (empirically verified).**
The shell helpers lowercased values through a command substitution — `case "$(lowercaseValue "$1")"` —
and command substitution strips trailing newlines. So `parseBoolean 'true<LF>'` returned `1` and
`isBooleanSpelling` accepted it, while `utils.js#parseBoolean` keeps the newline and returns `false`:

```
shell: 1
njs:   0
```

For an njs-consumed setting (e.g. `DEBUG`), a value with a trailing newline would pass startup
validation and then silently read as false at request time — exactly the divergence class GH-600 exists
to eliminate. The lowercased value now travels through a variable (`lowercaseValueInto`) with an `x`
sentinel protecting trailing newlines through the one internal substitution, making the shell exactly as
strict as njs. The installer's synced region is updated in lockstep; the drift-guard test gains an
explicit trailing-newline probe on both sides (the line-based spellings file cannot carry one), and
`utils_test.js` pins `'true\n'` as unrecognized.

**2. `envlib-sync-check` could pass vacuously.** The lint target extracted the marker-delimited region
from both files with `sed -n` and diffed the results — if the BEGIN marker ever disappeared from *both*
files, two empty extractions would diff clean. The target now fails with a pointed diagnostic when
either extraction comes back empty. Verified against scratch copies for all three outcomes: in-sync
pass, drifted-function failure, and stripped-marker failure.

Verified locally: `make lint` (including the hardened sync check), `make test-unit`, the boolean
validation entrypoint test (drift guard now covers the trailing-newline probe), and the
access-log/ipv6/secret-files entrypoint tests all pass against a rebuilt image.

### Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
