### PR TITLE
fix: install NGINX from the mainline branch on standalone hosts (#608)

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -512,6 +512,13 @@ that file from `http://nginx.org/packages/ubuntu` to
 sudo apt-get update && sudo apt-get upgrade
 ```
 
+A host set up before nginx.org rotated its signing keys on 2024-05-29 also has a
+`/usr/share/keyrings/nginx-archive-keyring.gpg` holding only the old 2011 key,
+which no longer signs any `Release` file — `apt-get update` fails there with
+`NO_PUBKEY` regardless of the branch. Re-running the install script rebuilds the
+keyring from the current key bundle, so run it before the commands above if
+`apt-get update` reports a missing key.
+
 ## Running in Containers
 
 ### Running the Public Open Source NGINX Container Image

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -493,6 +493,25 @@ For example:
 sudo env $(cat settings.example) ./standalone_ubuntu_oss_install.sh
 ```
 
+NGINX is installed from the
+[mainline package repository](https://nginx.org/en/linux_packages.html#Ubuntu)
+(`https://nginx.org/packages/mainline/ubuntu`), which is the same branch the
+container images track, so a systemd install runs the same NGINX version as a
+container deployment. Note that nginx.org labels the suite `stable` in both
+branches, so `apt-cache policy nginx` reports `nginx:stable` either way — the
+branch is selected by the repository URL, not by the suite name.
+
+Hosts installed before the gateway switched to mainline are still configured for
+the stable branch. The script never rewrites an existing
+`/etc/apt/sources.list.d/nginx.list` — so that local edits survive a re-run — and
+prints a warning instead. To migrate such a host, change the repository URL in
+that file from `http://nginx.org/packages/ubuntu` to
+`https://nginx.org/packages/mainline/ubuntu` and then run:
+
+```shell-session
+sudo apt-get update && sudo apt-get upgrade
+```
+
 ## Running in Containers
 
 ### Running the Public Open Source NGINX Container Image

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -531,13 +531,31 @@ if [ ! -f /usr/share/keyrings/nginx-archive-keyring.gpg ]; then
   rm -f "${key_tmp_file}"
 fi
 
+# The gateway container images build on the nginx.org mainline branch
+# (see Dockerfile.oss), so the standalone install tracks mainline as well. The
+# stable branch is cut roughly once a year, and installing from it would leave
+# systemd hosts a full development cycle behind every container deployment -
+# including any mainline feature the shared configuration templates adopt.
+nginx_repo_path="nginx.org/packages/mainline/ubuntu"
+nginx_repo_url="https://${nginx_repo_path}"
+
 if [ ! -f /etc/apt/sources.list.d/nginx.list ]; then
   release="$(grep 'VERSION_CODENAME' /etc/os-release | cut --delimiter='=' --field=2)"
   echo "▶ Adding NGINX package repository"
   echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
-  http://nginx.org/packages/ubuntu ${release} nginx" \
+  ${nginx_repo_url} ${release} nginx" \
       | sudo tee /etc/apt/sources.list.d/nginx.list
   apt-get -qq update
+elif ! grep --quiet --fixed-strings "${nginx_repo_path}" /etc/apt/sources.list.d/nginx.list; then
+  # An existing repository file is never rewritten, so local edits survive a
+  # re-run - which also means hosts installed before the mainline switch keep
+  # the stable branch until an operator migrates them by hand. The match is on
+  # the host and path only, so an operator who migrated the file by hand is not
+  # nagged over an unrelated difference such as an http:// scheme.
+  >&2 echo "WARNING: /etc/apt/sources.list.d/nginx.list does not reference ${nginx_repo_path}, so this host"
+  >&2 echo "WARNING: stays on the NGINX branch it was first installed from and may run an older NGINX than"
+  >&2 echo "WARNING: the gateway container images. To migrate, point the deb line in that file at"
+  >&2 echo "WARNING: ${nginx_repo_url} and then run: apt-get update && apt-get upgrade"
 fi
 
 to_install=""
@@ -547,8 +565,21 @@ if ! dpkg --status nginx 2>/dev/null | grep --quiet Status > /dev/null; then
 fi
 
 if ! dpkg --status nginx-module-njs 2>/dev/null | grep --quiet Status > /dev/null; then
-  # find latest njs version because the package manager gets this wrong
-  latest_njs_version="$(apt show -a nginx-module-njs 2>/dev/null | grep 'Version:' | cut --delimiter=' ' --field=2 | sort --reverse | head --lines=1)"
+  # find latest njs version because the package manager gets this wrong.
+  # The sort is version-aware: package versions embed the NGINX release
+  # (1.31.5+1.0.1-1~noble), so a plain lexicographic sort would rank
+  # 1.31.9 above 1.31.10 and pin njs to a version whose exact-match NGINX
+  # dependency conflicts with the mainline nginx package installed above.
+  # The trailing `|| true` keeps an empty result from aborting the script with
+  # no output: `grep` exits nonzero when apt lists no candidate, and errexit
+  # plus pipefail would turn that into a silent exit mid-install.
+  latest_njs_version="$(apt show -a nginx-module-njs 2>/dev/null | grep 'Version:' | cut --delimiter=' ' --field=2 | sort --version-sort --reverse | head --lines=1 || true)"
+  if [ -z "${latest_njs_version}" ]; then
+    >&2 echo "ERROR: apt lists no nginx-module-njs candidate, so the module version cannot be pinned."
+    >&2 echo "ERROR: check that /etc/apt/sources.list.d/nginx.list points at a repository carrying this"
+    >&2 echo "ERROR: release, run 'apt-get update', and then re-run this script."
+    exit 1
+  fi
   to_install="${to_install} nginx-module-njs=${latest_njs_version}"
 fi
 

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -522,11 +522,27 @@ echo "CORS Allow Private Network Access: ${CORS_ALLOW_PRIVATE_NETWORK_ACCESS}"
 
 set -o nounset   # abort on unbound variable
 
-if [ ! -f /usr/share/keyrings/nginx-archive-keyring.gpg ]; then
+# Fingerprint of the key that currently signs the repository metadata on both
+# nginx.org branches. A plain existence check on the keyring is not enough: a
+# host set up before nginx.org rotated keys on 2024-05-29 holds a keyring with
+# only the 2011 key 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 in it, which no
+# longer signs any Release file, so every apt-get update on that host fails with
+# NO_PUBKEY until the keyring is rebuilt from the current bundle.
+nginx_signing_key_fingerprint="8540A6F18833A80E9C1653A42FD21310B49F6B46"
+
+if [ ! -f /usr/share/keyrings/nginx-archive-keyring.gpg ] \
+    || ! gpg --show-keys --with-colons /usr/share/keyrings/nginx-archive-keyring.gpg 2>/dev/null \
+       | grep --quiet --fixed-strings "${nginx_signing_key_fingerprint}"; then
   echo "▶ Adding NGINX signing key"
   key_tmp_file="$(mktemp)"
   wget --quiet --max-redirect=3 --output-document="${key_tmp_file}" https://nginx.org/keys/nginx_signing.key
-  echo "dd4da5dc599ef9e7a7ac20a87275024b4923a917a306ab5d53fa77871220ecda  ${key_tmp_file}" | sha256sum --check
+  # Checksum of the published key bundle, which currently carries three keys:
+  # ABF5BD827BD9BF62 (2011, expires 2027-05-24) plus 2FD21310B49F6B46 and
+  # BCDCD8A38D88A2B3, both published 2024-05-29. nginx.org rewrites this file
+  # whenever it adds a key, and a stale pin aborts the install here, so re-pin
+  # the hash after checking the fingerprints against
+  # https://nginx.org/en/pgp_keys.html
+  echo "55385da31d198fa6a5012d40ae98ecb272a6c4e8fffffba94719ffd3e87de37a  ${key_tmp_file}" | sha256sum --check
   gpg --dearmor < "${key_tmp_file}" | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
   rm -f "${key_tmp_file}"
 fi

--- a/test/run_integration_tests.sh
+++ b/test/run_integration_tests.sh
@@ -691,7 +691,18 @@ start_tls_gateway() {
   tls_s3_server=${3:-rustfs}
   export TEST_S3_TRUSTED_CERT_PATH="${trusted_cert_path}"
   export TEST_S3_SERVER="${tls_s3_server}"
-  COMPOSE_COMPATIBILITY=true S3_STYLE="${tls_s3_style}" AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=1 PROVIDE_INDEX_PAGE=1 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=1 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose up -d
+  # --force-recreate because callers stop the gateway between sub-tests and can
+  # then start it again with an identical configuration - the hostname
+  # validation case does exactly that when S3_STYLE is already `path`. Without a
+  # config change to act on, `up -d` decides from the container state it
+  # observes, and that state can still read as running milliseconds after
+  # `compose stop` returns: compose then reports `Running`, does nothing, and
+  # leaves the gateway down until wait_for_gateway times out.
+  #
+  # Named explicitly so the recreation stops at the gateway. The origin holds
+  # the seeded bucket in its container filesystem rather than a volume, so
+  # recreating it here would silently empty the bucket every sub-test.
+  COMPOSE_COMPATIBILITY=true S3_STYLE="${tls_s3_style}" AWS_SIGS_VERSION=4 ALLOW_DIRECTORY_LIST=1 PROVIDE_INDEX_PAGE=1 APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=1 STRIP_LEADING_DIRECTORY_PATH="" PREFIX_LEADING_DIRECTORY_PATH="" DIRECTORY_LISTING_PAGE_SIZE="" compose up -d --force-recreate nginx-s3-gateway
   wait_for_gateway
 }
 


### PR DESCRIPTION
### Proposed changes

Fixes #608.

`standalone_ubuntu_oss_install.sh` configured the nginx.org **stable** APT repository while both
container images build on **mainline**, so a systemd install ran a different NGINX than every
container deployment — today 1.30.4 against the 1.31.5 that `Dockerfile.oss` pins. Stable is cut
roughly once a year, so the gap only widens, and any mainline feature the shared configuration
templates adopt would be unavailable on standalone hosts until the next branch cut.

**Repository branch** (c7678c9)

- The apt source now points at `https://nginx.org/packages/mainline/ubuntu`, which is what the
  official install guide documents. `http` → `https` is transport hardening only; apt verifies the
  repository signature either way.
- An existing `/etc/apt/sources.list.d/nginx.list` is still never rewritten, so local edits survive
  a re-run. That means pre-existing hosts do not migrate on their own, so a re-run now **warns**
  and prints the manual steps instead. The check matches on host and path rather than the full URL,
  so a host already migrated by hand over `http://` is not nagged about the scheme.
- The njs version pin is sorted with `--version-sort`. Mainline reaches double-digit patch releases
  within a branch year, where the old lexicographic sort ranks `1.31.9` above `1.31.10` and would
  pin `nginx-module-njs` to a version whose exact-match NGINX dependency conflicts with the `nginx`
  package installed in the same apt transaction. That pipeline also gained `|| true` plus an
  explicit emptiness check: `grep` exits nonzero when apt lists no candidate, and `errexit` with
  `pipefail` turned that into a silent exit part way through the install.

**Signing key** (d66031f) — found while verifying the above, and a prerequisite for it

- The pinned checksum `dd4da5dc…` matched the 1561-byte single-key file nginx.org published until
  May 2024. The published bundle now carries three keys (`ABF5BD827BD9BF62` from 2011, plus
  `2FD21310B49F6B46` and `BCDCD8A38D88A2B3`, both 2024-05-29) and hashes to `55385da3…`. Since
  `sha256sum --check` runs under `errexit`, **every first install has been aborting** at that step.
- Re-pinning alone is not enough. The block was guarded by a bare existence check on the keyring, so
  a host installed before the rotation keeps a keyring holding only the 2011 key. nginx.org now
  signs `InRelease` on both branches with `2FD21310B49F6B46`, so `apt-get update` there fails with
  `NO_PUBKEY` — which is the first command in the migration steps above. The guard now also rebuilds
  when the current signing fingerprint is absent, making a re-run the recovery path. gpg failing, or
  being too old for `--show-keys` (needs ≥ 2.2.8; 20.04 ships 2.2.19), reads as "fingerprint absent"
  and costs a redundant rebuild, never a skipped one.
- The pin stays a checksum rather than a fingerprint check — it covers exactly the bytes dearmored
  into the keyring — and a comment now records the fingerprints behind the hash and points at
  <https://nginx.org/en/pgp_keys.html> so the next rotation can be verified before the hash is bumped.

**Verification**

There is no automated coverage for the installer beyond shellcheck (it needs a root Ubuntu host), so
these paths were exercised by hand in `ubuntu:24.04` containers, running the script's blocks verbatim:

- Generated deb line resolves `nginx 1.31.5-1~noble`, `nginx-module-njs 1.31.5+1.0.1-1~noble` and
  `nginx-module-xslt 1.31.5-1~noble`, matching `Dockerfile.oss`; the stable repo currently offers 1.30.4.
- A pre-existing stable `nginx.list` produces the warning, leaves the file untouched, and continues.
- With a keyring dearmored from the old 2023 key, `apt-get update` fails `NO_PUBKEY 2FD21310B49F6B46`;
  the guard then rebuilds it, the same command succeeds, and a second pass over the block is a no-op.
- With no nginx repository configured, the njs lookup exits 1 with an actionable error instead of
  stopping silently.
- `make lint` passes (checkmake, shellcheck, rumdl, envlib sync check and its self-test).

**Documentation** — the systemd section of `docs/getting_started.md` now states the mainline branch,
gives the manual migration steps, covers the keyring rotation and its `NO_PUBKEY` recovery, and notes
that nginx.org labels the suite `stable` in *both* branches, so `apt-cache policy nginx` reporting
`nginx:stable` is not a failed migration.

**Deliberately untouched** — the container Dockerfiles, which already track mainline, and everything
in the installer outside the signing-key, repository and package-selection blocks.

**Test harness** (5b1d65e) — the `path` leg of this PR's first CI run failed at
"Verifying HTTPS S3 origin hostname validation" with `timed out after 15s waiting for the gateway`.
That is a pre-existing race, not this diff (neither the installer nor `docs/` is in the image):
`integration_test_proxy_ssl` stops the gateway and starts it again, and when the new configuration is
identical compose decides from observed container state — which still read as running 58 ms after
`compose stop` returned, so it reported `Running`, did nothing, and left the gateway down.

Only the `path` leg can reach it: `start_tls_gateway` resolves its style from `${2:-${S3_STYLE}}`, so
the call passing `"path"` explicitly matches the previous call exactly when the ambient style is
already `path`. The `virtual` and `virtual-v2` jobs of the same run log `Recreate/Recreated` at that
step. The fix force-recreates, scoped to the gateway service — the origin keeps its seeded bucket in
the container filesystem, so an unscoped recreate would empty the bucket before every TLS assertion.
Verified with `make build && make test-integration S3_STYLE=path`.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works. — the
      installer has no test harness (it needs a root Ubuntu host); the container checks above stand in.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).

